### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/Pr0methean/zip/compare/v1.1.1...v2.0.0) - 2024-04-28
+
+### <!-- 1 -->🐛 Bug Fixes
+- Alignment was previously handled incorrectly ([#33](https://github.com/Pr0methean/zip/pull/33))
+
+### <!-- 2 -->🚜 Refactor
+- [**breaking**] remove `deflate-miniz` feature since it's now equivalent to `deflate` ([#35](https://github.com/Pr0methean/zip/pull/35))
+
+### <!-- 9 -->◀️ Revert
+- refactor!: remove `deflate-miniz` feature since it's now equivalent to `deflate` ([#35](https://github.com/Pr0methean/zip/pull/35))"
+
 ## [1.1.1]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "1.1.1"
+version = "2.0.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION
## 🤖 New release
* `zip`: 1.1.1 -> 2.0.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/Pr0methean/zip/compare/v1.1.1...v2.0.0) - 2024-04-28

### <!-- 1 -->🐛 Bug Fixes
- Alignment was previously handled incorrectly ([#33](https://github.com/Pr0methean/zip/pull/33))

### <!-- 2 -->🚜 Refactor
- [**breaking**] remove `deflate-miniz` feature since it's now equivalent to `deflate` ([#35](https://github.com/Pr0methean/zip/pull/35))

### <!-- 9 -->◀️ Revert
- refactor!: remove `deflate-miniz` feature since it's now equivalent to `deflate` ([#35](https://github.com/Pr0methean/zip/pull/35))"
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).