### PR TITLE
feat: Switch to pure-Rust versions of bzip and zstd in order to pass static compiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ time = { version = "0.3.36", default-features = false }
 [dependencies]
 aes = { version = "0.8.4", optional = true }
 byteorder = "1.5.0"
-bzip2 = { version = "0.4.4", optional = true }
+bzip2-rs = { version = "0.1.2", optional = true }
 chrono = { version = "0.4.38", optional = true }
 constant_time_eq = { version = "0.3.0", optional = true }
 crc32fast = "1.4.0"
@@ -38,7 +38,7 @@ time = { workspace = true, optional = true, features = [
 zstd = { version = "0.13.1", optional = true, default-features = false }
 zopfli = { version = "0.8.0", optional = true }
 deflate64 = { version = "0.1.8", optional = true }
-lzma-rs = { version = "0.3.0", optional = true }
+lzma-rs = { version = "0.3.0", default-features = false, optional = true }
 
 [target.'cfg(any(all(target_arch = "arm", target_pointer_width = "32"), target_arch = "mips", target_arch = "powerpc"))'.dependencies]
 crossbeam-utils = "0.8.19"
@@ -68,7 +68,7 @@ lzma = ["lzma-rs/stream"]
 unreserved = []
 default = [
     "aes-crypto",
-    "bzip2",
+    "bzip2-rs",
     "deflate",
     "deflate64",
     "deflate-zlib-ng",


### PR DESCRIPTION
This replaces https://github.com/zip-rs/zip-old/pull/429.