### PR TITLE
feat: publicly export and document the zip64 threshold constants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 
 pub use crate::compression::{CompressionMethod, SUPPORTED_COMPRESSION_METHODS};
 pub use crate::read::ZipArchive;
+pub use crate::spec::{ZIP64_BYTES_THR, ZIP64_ENTRY_THR};
 pub use crate::types::DateTime;
 pub use crate::write::ZipWriter;
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -24,11 +24,11 @@ pub(crate) const ZIP64_CENTRAL_DIRECTORY_END_LOCATOR_SIGNATURE: u32 = 0x07064b50
 ///```
 /// # fn main() -> Result<(), zip::result::ZipError> {
 /// use std::io::{self, Cursor, prelude::*};
-/// use zip::{ZipWriter, write::FileOptions};
+/// use zip::{ZipWriter, write::SimpleFileOptions};
 ///
 /// let mut zip = ZipWriter::new(Cursor::new(Vec::new()));
 /// // Writing an extremely large file for this test is faster without compression.
-/// let options = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+/// let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
 ///
 /// let big_len: usize = (zip::ZIP64_BYTES_THR as usize) + 1;
 /// let big_buf = vec![0u8; big_len];


### PR DESCRIPTION
This replaces https://github.com/zip-rs/zip-old/pull/402.