### PR TITLE
feat: add ZipWriter::merge_archive() to efficiently copy all entries from a ZipArchive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,7 @@ harness = false
 [[bench]]
 name = "read_metadata"
 harness = false
+
+[[bench]]
+name = "merge_archive"
+harness = false

--- a/benches/merge_archive.rs
+++ b/benches/merge_archive.rs
@@ -1,0 +1,120 @@
+use bencher::{benchmark_group, benchmark_main};
+
+use std::io::{Cursor, Read, Seek, Write};
+
+use bencher::Bencher;
+use getrandom::getrandom;
+use zip::{result::ZipResult, write::FileOptions, ZipArchive, ZipWriter};
+
+fn generate_random_archive(
+    num_entries: usize,
+    entry_size: usize,
+    options: FileOptions,
+) -> ZipResult<(usize, ZipArchive<Cursor<Vec<u8>>>)> {
+    let buf = Cursor::new(Vec::new());
+    let mut zip = ZipWriter::new(buf);
+
+    let mut bytes = vec![0u8; entry_size];
+    for i in 0..num_entries {
+        let name = format!("random{}.dat", i);
+        zip.start_file(name, options)?;
+        getrandom(&mut bytes).unwrap();
+        zip.write_all(&bytes)?;
+    }
+
+    let buf = zip.finish()?.into_inner();
+    let len = buf.len();
+
+    Ok((len, ZipArchive::new(Cursor::new(buf))?))
+}
+
+fn perform_merge<R: Read + Seek, W: Write + Seek>(
+    src: ZipArchive<R>,
+    mut target: ZipWriter<W>,
+) -> ZipResult<ZipWriter<W>> {
+    target.merge_archive(src)?;
+    Ok(target)
+}
+
+fn perform_raw_copy_file<R: Read + Seek, W: Write + Seek>(
+    mut src: ZipArchive<R>,
+    mut target: ZipWriter<W>,
+) -> ZipResult<ZipWriter<W>> {
+    for i in 0..src.len() {
+        let entry = src.by_index(i)?;
+        target.raw_copy_file(entry)?;
+    }
+    Ok(target)
+}
+
+const NUM_ENTRIES: usize = 100;
+const ENTRY_SIZE: usize = 1024;
+
+fn merge_archive_stored(bench: &mut Bencher) {
+    let options = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let (len, src) = generate_random_archive(NUM_ENTRIES, ENTRY_SIZE, options).unwrap();
+
+    bench.bytes = len as u64;
+
+    bench.iter(|| {
+        let buf = Cursor::new(Vec::new());
+        let zip = ZipWriter::new(buf);
+        let mut zip = perform_merge(src.clone(), zip).unwrap();
+        let buf = zip.finish().unwrap().into_inner();
+        assert_eq!(buf.len(), len);
+    });
+}
+
+fn merge_archive_compressed(bench: &mut Bencher) {
+    let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+    let (len, src) = generate_random_archive(NUM_ENTRIES, ENTRY_SIZE, options).unwrap();
+
+    bench.bytes = len as u64;
+
+    bench.iter(|| {
+        let buf = Cursor::new(Vec::new());
+        let zip = ZipWriter::new(buf);
+        let mut zip = perform_merge(src.clone(), zip).unwrap();
+        let buf = zip.finish().unwrap().into_inner();
+        assert_eq!(buf.len(), len);
+    });
+}
+
+fn merge_archive_raw_copy_file_stored(bench: &mut Bencher) {
+    let options = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let (len, src) = generate_random_archive(NUM_ENTRIES, ENTRY_SIZE, options).unwrap();
+
+    bench.bytes = len as u64;
+
+    bench.iter(|| {
+        let buf = Cursor::new(Vec::new());
+        let zip = ZipWriter::new(buf);
+        let mut zip = perform_raw_copy_file(src.clone(), zip).unwrap();
+        let buf = zip.finish().unwrap().into_inner();
+        assert_eq!(buf.len(), len);
+    });
+}
+
+fn merge_archive_raw_copy_file_compressed(bench: &mut Bencher) {
+    let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+    let (len, src) = generate_random_archive(NUM_ENTRIES, ENTRY_SIZE, options).unwrap();
+
+    bench.bytes = len as u64;
+
+    bench.iter(|| {
+        let buf = Cursor::new(Vec::new());
+        let zip = ZipWriter::new(buf);
+        let mut zip = perform_raw_copy_file(src.clone(), zip).unwrap();
+        let buf = zip.finish().unwrap().into_inner();
+        assert_eq!(buf.len(), len);
+    });
+}
+
+benchmark_group!(
+    benches,
+    merge_archive_stored,
+    merge_archive_compressed,
+    merge_archive_raw_copy_file_stored,
+    merge_archive_raw_copy_file_compressed,
+);
+benchmark_main!(benches);

--- a/src/write.rs
+++ b/src/write.rs
@@ -931,21 +931,8 @@ impl<W: Write + Seek> ZipWriter<W> {
         let new_files = source.merge_contents(writer)?;
 
         /* These file entries are now ours! */
-        self.files.extend(new_files);
+        self.files.extend(new_files.into_vec());
 
-        Ok(())
-    }
-
-    /// Create a file in the archive and start writing its' contents.
-    ///
-    /// The data should be written using the [`io::Write`] implementation on this [`ZipWriter`]
-    pub fn start_file<S>(&mut self, name: S, mut options: FileOptions) -> ZipResult<()>
-    where
-        S: Into<String>,
-    {
-        if options.permissions.is_none() {
-            options.permissions = Some(0o644);
-        }
         Ok(())
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -886,17 +886,17 @@ impl<W: Write + Seek> ZipWriter<W> {
     ///```
     /// # fn main() -> Result<(), zip::result::ZipError> {
     /// use std::io::{Cursor, prelude::*};
-    /// use zip::{ZipArchive, ZipWriter, write::FileOptions};
+    /// use zip::{ZipArchive, ZipWriter, write::SimpleFileOptions};
     ///
     /// let buf = Cursor::new(Vec::new());
     /// let mut zip = ZipWriter::new(buf);
-    /// zip.start_file("a.txt", FileOptions::default())?;
+    /// zip.start_file("a.txt", SimpleFileOptions::default())?;
     /// zip.write_all(b"hello\n")?;
     /// let src = ZipArchive::new(zip.finish()?)?;
     ///
     /// let buf = Cursor::new(Vec::new());
     /// let mut zip = ZipWriter::new(buf);
-    /// zip.start_file("b.txt", FileOptions::default())?;
+    /// zip.start_file("b.txt", SimpleFileOptions::default())?;
     /// zip.write_all(b"hey\n")?;
     /// let src2 = ZipArchive::new(zip.finish()?)?;
     ///

--- a/src/write.rs
+++ b/src/write.rs
@@ -874,6 +874,81 @@ impl<W: Write + Seek> ZipWriter<W> {
         Ok(())
     }
 
+    /* TODO: link to/use Self::finish_into_readable() from https://github.com/zip-rs/zip/pull/400 in
+     * this docstring. */
+    /// Copy over the entire contents of another archive verbatim.
+    ///
+    /// This method extracts file metadata from the `source` archive, then simply performs a single
+    /// big [`io::copy()`](io::copy) to transfer all the actual file contents without any
+    /// decompression or decryption. This is more performant than the equivalent operation of
+    /// calling [`Self::raw_copy_file()`] for each entry from the `source` archive in sequence.
+    ///
+    ///```
+    /// # fn main() -> Result<(), zip::result::ZipError> {
+    /// use std::io::{Cursor, prelude::*};
+    /// use zip::{ZipArchive, ZipWriter, write::FileOptions};
+    ///
+    /// let buf = Cursor::new(Vec::new());
+    /// let mut zip = ZipWriter::new(buf);
+    /// zip.start_file("a.txt", FileOptions::default())?;
+    /// zip.write_all(b"hello\n")?;
+    /// let src = ZipArchive::new(zip.finish()?)?;
+    ///
+    /// let buf = Cursor::new(Vec::new());
+    /// let mut zip = ZipWriter::new(buf);
+    /// zip.start_file("b.txt", FileOptions::default())?;
+    /// zip.write_all(b"hey\n")?;
+    /// let src2 = ZipArchive::new(zip.finish()?)?;
+    ///
+    /// let buf = Cursor::new(Vec::new());
+    /// let mut zip = ZipWriter::new(buf);
+    /// zip.merge_archive(src)?;
+    /// zip.merge_archive(src2)?;
+    /// let mut result = ZipArchive::new(zip.finish()?)?;
+    ///
+    /// let mut s: String = String::new();
+    /// result.by_name("a.txt")?.read_to_string(&mut s)?;
+    /// assert_eq!(s, "hello\n");
+    /// s.clear();
+    /// result.by_name("b.txt")?.read_to_string(&mut s)?;
+    /// assert_eq!(s, "hey\n");
+    /// # Ok(())
+    /// # }
+    ///```
+    pub fn merge_archive<R>(&mut self, mut source: ZipArchive<R>) -> ZipResult<()>
+    where
+        R: Read + io::Seek,
+    {
+        self.finish_file()?;
+
+        /* Ensure we accept the file contents on faith (and avoid overwriting the data).
+         * See raw_copy_file_rename(). */
+        self.writing_to_file = true;
+        self.writing_raw = true;
+
+        let writer = self.inner.get_plain();
+        /* Get the file entries from the source archive. */
+        let new_files = source.merge_contents(writer)?;
+
+        /* These file entries are now ours! */
+        self.files.extend(new_files);
+
+        Ok(())
+    }
+
+    /// Create a file in the archive and start writing its' contents.
+    ///
+    /// The data should be written using the [`io::Write`] implementation on this [`ZipWriter`]
+    pub fn start_file<S>(&mut self, name: S, mut options: FileOptions) -> ZipResult<()>
+    where
+        S: Into<String>,
+    {
+        if options.permissions.is_none() {
+            options.permissions = Some(0o644);
+        }
+        Ok(())
+    }
+
     /// Removes the file currently being written from the archive if there is one, or else removes
     /// the file most recently written.
     pub fn abort_file(&mut self) -> ZipResult<()> {


### PR DESCRIPTION
This replaces https://github.com/zip-rs/zip-old/pull/401.