### PR TITLE
refactor: use displaydoc and thiserror to remove some boilerplate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bzip2 = { version = "0.4.4", optional = true }
 chrono = { version = "0.4.38", optional = true }
 constant_time_eq = { version = "0.3.0", optional = true }
 crc32fast = "1.4.0"
-displaydoc = "0.2.4"
+displaydoc = { version = "0.2.4", default-features = false }
 thiserror = "1.0.48"
 flate2 = { version = "1.0.28", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 //! Error types that can be emitted from this library
 
 use displaydoc::Display;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints)] // non_local_definitions isn't in Rust 1.70
 #![allow(non_local_definitions)]
 //! Error types that can be emitted from this library
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -6,7 +6,6 @@ use thiserror::Error;
 use std::error::Error;
 use std::fmt;
 use std::io;
-use std::io::IntoInnerError;
 use std::num::TryFromIntError;
 
 /// Generic result type with ZipError as its error variant

--- a/src/write.rs
+++ b/src/write.rs
@@ -1418,7 +1418,7 @@ impl<W: Write + Seek> GenericZipWriter<W> {
             #[cfg(feature = "deflate-zopfli")]
             GenericZipWriter::ZopfliDeflater(w) => w.finish()?,
             #[cfg(feature = "deflate-zopfli")]
-            GenericZipWriter::BufferedZopfliDeflater(w) => w.into_inner()?.finish()?,
+            GenericZipWriter::BufferedZopfliDeflater(w) => w.into_inner().map_err(|e| ZipError::Io(e.into_error()))?.finish()?,
             #[cfg(feature = "bzip2")]
             GenericZipWriter::Bzip2(w) => w.finish()?,
             #[cfg(feature = "zstd")]

--- a/src/write.rs
+++ b/src/write.rs
@@ -1418,7 +1418,10 @@ impl<W: Write + Seek> GenericZipWriter<W> {
             #[cfg(feature = "deflate-zopfli")]
             GenericZipWriter::ZopfliDeflater(w) => w.finish()?,
             #[cfg(feature = "deflate-zopfli")]
-            GenericZipWriter::BufferedZopfliDeflater(w) => w.into_inner().map_err(|e| ZipError::Io(e.into_error()))?.finish()?,
+            GenericZipWriter::BufferedZopfliDeflater(w) => w
+                .into_inner()
+                .map_err(|e| ZipError::Io(e.into_error()))?
+                .finish()?,
             #[cfg(feature = "bzip2")]
             GenericZipWriter::Bzip2(w) => w.finish()?,
             #[cfg(feature = "zstd")]


### PR DESCRIPTION
This replaces https://github.com/zip-rs/zip-old/pull/397.