### PR TITLE
ci: Run cargo doc and clippy with default features, all features and no features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,13 +52,12 @@ jobs:
         command: test
         args: --all ${{ matrix.feature_flag }}
 
-  style_and_docs:
+  cargo_fmt:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -67,18 +66,30 @@ jobs:
           components: rustfmt, clippy
       - name: fmt
         run: cargo fmt --all -- --check
-      - name: clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
-      - name: Docs
-        run: cargo doc --no-deps
+
+  style_and_docs:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    strategy:
+      matrix:
+        feature_flag: ["--all-features", "--no-default-features", ""]
+    runs-on: ubuntu-latest
+    steps:
+     - name: clippy
+       uses: actions-rs/cargo@v1
+       with:
+         command: clippy
+         args: --all-targets ${{ matrix.feature_flag }} -- -D warnings
+     - name: docs
+       uses: actions-rs/cargo@v1
+       with:
+         command: doc
+         args: --no-deps --all-targets ${{ matrix.feature_flag }} -- -D warnings
 
   fuzz_read:
     runs-on: ubuntu-latest
     needs:
       - build_and_test
+      - cargo_fmt
       - style_and_docs
     steps:
       - uses: actions/checkout@v4
@@ -126,6 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_and_test
+      - cargo_fmt
       - style_and_docs
     steps:
       - uses: actions/checkout@v4
@@ -173,6 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_and_test
+      - cargo_fmt
       - style_and_docs
     steps:
       - uses: actions/checkout@v4
@@ -220,6 +233,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_and_test
+      - cargo_fmt
       - style_and_docs
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-          components: rustfmt, clippy
+          components: rustfmt
       - name: fmt
         run: cargo fmt --all -- --check
 
@@ -74,16 +74,23 @@ jobs:
         feature_flag: ["--all-features", "--no-default-features", ""]
     runs-on: ubuntu-latest
     steps:
-     - name: clippy
-       uses: actions-rs/cargo@v1
-       with:
-         command: clippy
-         args: --all-targets ${{ matrix.feature_flag }} -- -D warnings
-     - name: docs
-       uses: actions-rs/cargo@v1
-       with:
-         command: doc
-         args: --no-deps --all-targets ${{ matrix.feature_flag }} -- -D warnings
+    - uses: actions/checkout@v4
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
+        components: clippy
+    - name: clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --all-targets ${{ matrix.feature_flag }} -- -D warnings
+    - name: docs
+      uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-deps --all-targets ${{ matrix.feature_flag }} -- -D warnings
 
   fuzz_read:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: doc
-        args: --no-deps --all-targets ${{ matrix.feature_flag }} -- -D warnings
+        args: --no-deps ${{ matrix.feature_flag }} -- -D warnings
 
   fuzz_read:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: doc
-        args: --no-deps ${{ matrix.feature_flag }} -- -D warnings
+        args: --no-deps ${{ matrix.feature_flag }}
 
   fuzz_read:
     runs-on: ubuntu-latest

--- a/benches/merge_archive.rs
+++ b/benches/merge_archive.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "_deflate-any")]
-
 use bencher::{benchmark_group, benchmark_main};
 
 use std::io::{Cursor, Read, Seek, Write};
@@ -67,6 +65,7 @@ fn merge_archive_stored(bench: &mut Bencher) {
     });
 }
 
+#[cfg(feature = "_deflate-any")]
 fn merge_archive_compressed(bench: &mut Bencher) {
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
     let (len, src) = generate_random_archive(NUM_ENTRIES, ENTRY_SIZE, options).unwrap();
@@ -97,6 +96,7 @@ fn merge_archive_raw_copy_file_stored(bench: &mut Bencher) {
     });
 }
 
+#[cfg(feature = "_deflate-any")]
 fn merge_archive_raw_copy_file_compressed(bench: &mut Bencher) {
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
     let (len, src) = generate_random_archive(NUM_ENTRIES, ENTRY_SIZE, options).unwrap();
@@ -112,6 +112,7 @@ fn merge_archive_raw_copy_file_compressed(bench: &mut Bencher) {
     });
 }
 
+#[cfg(feature = "_deflate-any")]
 benchmark_group!(
     benches,
     merge_archive_stored,
@@ -119,4 +120,12 @@ benchmark_group!(
     merge_archive_raw_copy_file_stored,
     merge_archive_raw_copy_file_compressed,
 );
+
+#[cfg(not(feature = "_deflate-any"))]
+benchmark_group!(
+    benches,
+    merge_archive_stored,
+    merge_archive_raw_copy_file_stored,
+);
+
 benchmark_main!(benches);

--- a/benches/merge_archive.rs
+++ b/benches/merge_archive.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "_deflate-any")]
+
 use bencher::{benchmark_group, benchmark_main};
 
 use std::io::{Cursor, Read, Seek, Write};


### PR DESCRIPTION
This should detect issues in feature-gated parts of the code and their docstrings more reliably.