### PR TITLE
chore: release v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.1.4](https://github.com/zip-rs/zip2/compare/v1.1.3...v1.1.4) - 2024-05-04
+
+### <!-- 1 -->🐛 Bug Fixes
+- Build was failing with bzip2 enabled
+- use is_dir in more places where Windows paths might be handled incorrectly
+
+### <!-- 4 -->⚡ Performance
+- Quick filter for paths that contain "/../" or "/./" or start with "./" or "../"
+- Fast handling for separator-free paths
+- Speed up logic if main separator isn't '/'
+- Drop `normalized_components` slightly sooner when not using it
+- Speed up `path_to_string` in cases where the path is already in the proper format
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+- Refactor: can short-circuit handling of paths that start with MAIN_SEPARATOR, no matter what MAIN_SEPARATOR is
+- Bug fix: non-canonical path detection when MAIN_SEPARATOR is not slash or occurs twice in a row
+- Bug fix: must recreate if . or .. is a path element
+- Bug fix
+
+### <!-- 9 -->◀️ Revert
+- [#58](https://github.com/zip-rs/zip2/pull/58) (partial): `bzip2-rs` can't replace `bzip2` because it's decompress-only
+
 ## [1.1.3](https://github.com/zip-rs/zip2/compare/v1.1.2...v1.1.3) - 2024-04-30
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION
## 🤖 New release
* `zip`: 1.1.3 -> 1.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.4](https://github.com/zip-rs/zip2/compare/v1.1.3...v1.1.4) - 2024-05-04

### <!-- 1 -->🐛 Bug Fixes
- Build was failing with bzip2 enabled
- use is_dir in more places where Windows paths might be handled incorrectly

### <!-- 4 -->⚡ Performance
- Quick filter for paths that contain "/../" or "/./" or start with "./" or "../"
- Fast handling for separator-free paths
- Speed up logic if main separator isn't '/'
- Drop `normalized_components` slightly sooner when not using it
- Speed up `path_to_string` in cases where the path is already in the proper format

### <!-- 7 -->⚙️ Miscellaneous Tasks
- Refactor: can short-circuit handling of paths that start with MAIN_SEPARATOR, no matter what MAIN_SEPARATOR is
- Bug fix: non-canonical path detection when MAIN_SEPARATOR is not slash or occurs twice in a row
- Bug fix: must recreate if . or .. is a path element
- Bug fix

### <!-- 9 -->◀️ Revert
- [#58](https://github.com/zip-rs/zip2/pull/58) (partial): `bzip2-rs` can't replace `bzip2` because it's decompress-only
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).