### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.2.0](https://github.com/zip-rs/zip2/compare/v1.1.4...v1.2.0) - 2024-05-06
+
+### <!-- 0 -->🚀 Features
+- Add method `decompressed_size()` so non-recursive ZIP bombs can be detected
+
+### <!-- 2 -->🚜 Refactor
+- Make `ZipWriter::finish()` consume the `ZipWriter`
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+- Use panic! rather than abort to ensure the fuzz harness can process the failure
+- Update fuzz_write to use replace_with
+- Remove a drop that can no longer be explicit
+- Add `#![allow(unexpected_cfgs)]` in nightly
+
 ## [1.1.4](https://github.com/zip-rs/zip2/compare/v1.1.3...v1.1.4) - 2024-05-04
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "1.1.4"
+version = "1.2.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION
## 🤖 New release
* `zip`: 1.1.4 -> 1.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.0](https://github.com/zip-rs/zip2/compare/v1.1.4...v1.2.0) - 2024-05-06

### <!-- 0 -->🚀 Features
- Add method `decompressed_size()` so non-recursive ZIP bombs can be detected

### <!-- 2 -->🚜 Refactor
- Make `ZipWriter::finish()` consume the `ZipWriter`

### <!-- 7 -->⚙️ Miscellaneous Tasks
- Use panic! rather than abort to ensure the fuzz harness can process the failure
- Update fuzz_write to use replace_with
- Remove a drop that can no longer be explicit
- Add `#![allow(unexpected_cfgs)]` in nightly
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).