### PR TITLE
refactor: Make `ZipWriter::finish()` consume the `ZipWriter`

### DIFF
--- a/benches/merge_archive.rs
+++ b/benches/merge_archive.rs
@@ -59,7 +59,7 @@ fn merge_archive_stored(bench: &mut Bencher) {
     bench.iter(|| {
         let buf = Cursor::new(Vec::new());
         let zip = ZipWriter::new(buf);
-        let mut zip = perform_merge(src.clone(), zip).unwrap();
+        let zip = perform_merge(src.clone(), zip).unwrap();
         let buf = zip.finish().unwrap().into_inner();
         assert_eq!(buf.len(), len);
     });
@@ -75,7 +75,7 @@ fn merge_archive_compressed(bench: &mut Bencher) {
     bench.iter(|| {
         let buf = Cursor::new(Vec::new());
         let zip = ZipWriter::new(buf);
-        let mut zip = perform_merge(src.clone(), zip).unwrap();
+        let zip = perform_merge(src.clone(), zip).unwrap();
         let buf = zip.finish().unwrap().into_inner();
         assert_eq!(buf.len(), len);
     });
@@ -90,7 +90,7 @@ fn merge_archive_raw_copy_file_stored(bench: &mut Bencher) {
     bench.iter(|| {
         let buf = Cursor::new(Vec::new());
         let zip = ZipWriter::new(buf);
-        let mut zip = perform_raw_copy_file(src.clone(), zip).unwrap();
+        let zip = perform_raw_copy_file(src.clone(), zip).unwrap();
         let buf = zip.finish().unwrap().into_inner();
         assert_eq!(buf.len(), len);
     });
@@ -106,7 +106,7 @@ fn merge_archive_raw_copy_file_compressed(bench: &mut Bencher) {
     bench.iter(|| {
         let buf = Cursor::new(Vec::new());
         let zip = ZipWriter::new(buf);
-        let mut zip = perform_raw_copy_file(src.clone(), zip).unwrap();
+        let zip = perform_raw_copy_file(src.clone(), zip).unwrap();
         let buf = zip.finish().unwrap().into_inner();
         assert_eq!(buf.len(), len);
     });

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1.3.0", features = ["derive"] }
+replace_with = "0.1.7"
 
 [dependencies.zip]
 path = ".."

--- a/fuzz/fuzz_targets/fuzz_write.rs
+++ b/fuzz/fuzz_targets/fuzz_write.rs
@@ -2,7 +2,7 @@
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use replace_with::replace_with_or_abort;
+use replace_with::replace_with;
 use std::io::{Cursor, Read, Seek, Write};
 use std::path::PathBuf;
 
@@ -83,7 +83,9 @@ where
     }
     if operation.reopen {
         let old_comment = writer.get_raw_comment().to_owned();
-        replace_with_or_abort(writer, |old_writer: zip::ZipWriter<T>| {
+        replace_with(writer, || {
+            panic!("Failed to reopen writer");
+        }, |old_writer: zip::ZipWriter<T>| {
             let new_writer =
                 zip::ZipWriter::new_append(old_writer.finish().unwrap()).unwrap();
             assert_eq!(&old_comment, new_writer.get_raw_comment());

--- a/fuzz/fuzz_targets/fuzz_write.rs
+++ b/fuzz/fuzz_targets/fuzz_write.rs
@@ -2,7 +2,7 @@
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use replace_with::replace_with;
+use replace_with::replace_with_or_abort;
 use std::io::{Cursor, Read, Seek, Write};
 use std::path::PathBuf;
 
@@ -83,9 +83,7 @@ where
     }
     if operation.reopen {
         let old_comment = writer.get_raw_comment().to_owned();
-        replace_with(writer, || {
-            panic!("Failed to reopen writer");
-        }, |old_writer: zip::ZipWriter<T>| {
+        replace_with_or_abort(writer, |old_writer: zip::ZipWriter<T>| {
             let new_writer =
                 zip::ZipWriter::new_append(old_writer.finish().unwrap()).unwrap();
             assert_eq!(&old_comment, new_writer.get_raw_comment());

--- a/src/write.rs
+++ b/src/write.rs
@@ -1188,7 +1188,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     ///
     /// This will return the writer, but one should normally not append any data to the end of the file.
     /// Note that the zipfile will also be finished on drop.
-    pub fn finish(&mut self) -> ZipResult<W> {
+    pub fn finish(mut self) -> ZipResult<W> {
         let _central_start = self.finalize()?;
         let inner = mem::replace(&mut self.inner, Closed);
         Ok(inner.unwrap())
@@ -1440,14 +1440,13 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                         feature = "deflate-zlib-ng",
                     ))]
                     {
-                        return Ok(Box::new(move |bare| {
+                        Ok(Box::new(move |bare| {
                             GenericZipWriter::Deflater(DeflateEncoder::new(
                                 bare,
                                 Compression::new(level),
                             ))
-                        }));
+                        }))
                     }
-                    unreachable!()
                 }
                 #[cfg(feature = "deflate64")]
                 CompressionMethod::Deflate64 => Err(ZipError::UnsupportedArchive(

--- a/tests/zip_crypto.rs
+++ b/tests/zip_crypto.rs
@@ -49,7 +49,6 @@ fn encrypting_file() {
         .unwrap();
     archive.write_all(b"test").unwrap();
     archive.finish().unwrap();
-    drop(archive);
     let mut archive = zip::ZipArchive::new(Cursor::new(&mut buf)).unwrap();
     let mut file = archive.by_index_decrypt(0, b"password").unwrap();
     let mut buf = Vec::new();


### PR DESCRIPTION
This prevents the reuse of a closed ZipWriter at compile-time; currently it's a runtime Err result.