### PR TITLE
feat: Allow the archive offset behavior of the reader to be configured.

### DIFF
--- a/src/read/config.rs
+++ b/src/read/config.rs
@@ -1,0 +1,22 @@
+/// Configuration for reading ZIP archives.
+#[repr(transparent)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Config {
+    /// An offset into the reader to use to find the start of the archive.
+    pub archive_offset: ArchiveOffset,
+}
+
+/// The offset of the start of the archive from the beginning of the reader.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArchiveOffset {
+    /// Try to detect the archive offset automatically.
+    ///
+    /// This will look at the central directory specified by `FromCentralDirectory` for a header.
+    /// If missing, this will behave as if `None` were specified.
+    #[default]
+    Detect,
+    /// Use the central directory length and offset to determine the start of the archive.
+    FromCentralDirectory,
+    /// Specify a fixed archive offset.
+    Known(u64),
+}


### PR DESCRIPTION
Aside from supporting the current behavior which allows archives to be preceded by arbitrary data (added in fc749a09), this also allows detection of the offset to use by checking whether a central directory header is at the expected location. This is configurable because if the behavior were based only on detection, there could be false positives if archive data happened to contain a central directory header at the right spot.

The motivation for this was to support slightly non-standard central directory locations (such as described [here](https://taras.glek.net/post/optimized-zip-format/)).

<!-- 
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Please make sure your PR's target repo is `zip-rs/zip2` and not `zip-rs/zip-old`. The latter
  repo is no longer maintained, and I will archive it after closing the pre-existing issues.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- Commit messages and the PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start 
  with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
- All commits must be signed and display a "Verified" badge; see 
  https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification.
  If any of your commits don't have a "Verified" badge, here's how to fix this:
  1. Generate a GPG key if you don't already have one, by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key.
  2. If you use GitHub's email privacy feature, associate the key with your users.noreply.github.com email address by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/associating-an-email-with-your-gpg-key.
  3. Configure Git to use your signing key by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key
  4. Add the key to your GitHub account by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account
  5. Enable commit signing by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
  6. Squash your PR into one commit or run `git commit --amend --no-edit`, because enabling commit signing isn't retroactive
     even for unpushed commits.

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->
