### PR TITLE
Impl a "std" feature on cases where std::ioRead/Write/Seek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ clap = { version = "=4.4.18", features = ["derive"] }
 tempdir = "0.3.7"
 
 [features]
+std = []
 aes-crypto = ["aes", "constant_time_eq", "hmac", "pbkdf2", "sha1", "rand", "zeroize"]
 chrono = ["chrono/default"]
 _deflate-any = []
@@ -81,6 +82,7 @@ default = [
     "deflate-zlib-ng",
     "deflate-zopfli",
     "lzma",
+    "std",
     "time",
     "zstd",
 ]

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -66,6 +66,7 @@ pub struct AesReader<R> {
     data_length: u64,
 }
 
+#[cfg(feature = "std")]
 impl<R: Read> AesReader<R> {
     pub const fn new(reader: R, aes_mode: AesMode, compressed_size: u64) -> AesReader<R> {
         let data_length = compressed_size
@@ -139,6 +140,7 @@ pub struct AesReaderValid<R: Read> {
     finalized: bool,
 }
 
+#[cfg(feature = "std")]
 impl<R: Read> Read for AesReaderValid<R> {
     /// This implementation does not fulfill all requirements set in the trait documentation.
     ///
@@ -195,6 +197,7 @@ impl<R: Read> Read for AesReaderValid<R> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<R: Read> AesReaderValid<R> {
     /// Consumes this decoder, returning the underlying reader.
     pub fn into_inner(self) -> R {
@@ -210,6 +213,7 @@ pub struct AesWriter<W> {
     encrypted_file_header: Option<Vec<u8>>,
 }
 
+#[cfg(feature = "std")]
 impl<W: Write> AesWriter<W> {
     pub fn new(writer: W, aes_mode: AesMode, password: &[u8]) -> io::Result<Self> {
         let salt_length = aes_mode.salt_length();
@@ -269,6 +273,7 @@ impl<W: Write> AesWriter<W> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<W: Write> Write for AesWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.write_encrypted_file_header()?;

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -132,6 +132,7 @@ impl<R: Read> AesReader<R> {
 /// There is a 1 in 65536 chance that an invalid password passes that check.
 /// After the data has been read and decrypted an HMAC will be checked and provide a final means
 /// to check if either the password is invalid or if the data has been changed.
+#[cfg(feature = "std")]
 pub struct AesReaderValid<R: Read> {
     reader: R,
     data_remaining: u64,

--- a/src/aes_ctr.rs
+++ b/src/aes_ctr.rs
@@ -99,6 +99,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<C> AesCipher for AesCtrZipKeyStream<C>
 where
     C: AesKind,
@@ -134,6 +135,7 @@ where
 
 /// This trait allows using generic AES ciphers with different key sizes.
 pub trait AesCipher {
+    #[cfg(feature = "std")]
     fn crypt_in_place(&mut self, target: &mut [u8]);
 }
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -36,6 +36,7 @@ impl<R> Crc32Reader<R> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<R: Read> Read for Crc32Reader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let invalid_check = !buf.is_empty() && !self.check_matches() && !self.ae2_encrypted;

--- a/src/extra_fields/extended_timestamp.rs
+++ b/src/extra_fields/extended_timestamp.rs
@@ -11,6 +11,7 @@ pub struct ExtendedTimestamp {
     cr_time: Option<u32>,
 }
 
+#[cfg(feature = "std")]
 impl ExtendedTimestamp {
     /// creates an extended timestamp struct by reading the required bytes from the reader.
     ///

--- a/src/read.rs
+++ b/src/read.rs
@@ -89,6 +89,7 @@ use crate::unstable::LittleEndianReadExt;
 pub use zip_archive::ZipArchive;
 
 #[allow(clippy::large_enum_variant)]
+#[cfg(feature = "std")]
 pub(crate) enum CryptoReader<'a> {
     Plaintext(io::Take<&'a mut dyn Read>),
     ZipCrypto(ZipCryptoReaderValid<io::Take<&'a mut dyn Read>>),
@@ -99,6 +100,7 @@ pub(crate) enum CryptoReader<'a> {
     },
 }
 
+#[cfg(feature = "std")]
 impl<'a> Read for CryptoReader<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
@@ -110,6 +112,7 @@ impl<'a> Read for CryptoReader<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> CryptoReader<'a> {
     /// Consumes this decoder, returning the underlying reader.
     pub fn into_inner(self) -> io::Take<&'a mut dyn Read> {
@@ -136,6 +139,7 @@ impl<'a> CryptoReader<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 pub(crate) enum ZipFileReader<'a> {
     NoReader,
     Raw(io::Take<&'a mut dyn Read>),
@@ -152,6 +156,7 @@ pub(crate) enum ZipFileReader<'a> {
     Lzma(Crc32Reader<Box<LzmaDecoder<CryptoReader<'a>>>>),
 }
 
+#[cfg(feature = "std")]
 impl<'a> Read for ZipFileReader<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
@@ -172,6 +177,7 @@ impl<'a> Read for ZipFileReader<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> ZipFileReader<'a> {
     /// Consumes this decoder, returning the underlying reader.
     pub fn drain(self) {
@@ -204,7 +210,9 @@ impl<'a> ZipFileReader<'a> {
 /// A struct for reading a zip file
 pub struct ZipFile<'a> {
     pub(crate) data: Cow<'a, ZipFileData>,
+    #[cfg(feature = "std")]
     pub(crate) crypto_reader: Option<CryptoReader<'a>>,
+    #[cfg(feature = "std")]
     pub(crate) reader: ZipFileReader<'a>,
 }
 
@@ -237,6 +245,7 @@ pub(crate) fn find_content<'a>(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(feature = "std")]
 pub(crate) fn make_crypto_reader<'a>(
     compression_method: CompressionMethod,
     crc32: u32,
@@ -280,6 +289,7 @@ pub(crate) fn make_crypto_reader<'a>(
     Ok(reader)
 }
 
+#[cfg(feature = "std")]
 pub(crate) fn make_reader(
     compression_method: CompressionMethod,
     crc32: u32,
@@ -387,6 +397,7 @@ impl<R> ZipArchive<R> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<R: Read + Seek> ZipArchive<R> {
     pub(crate) fn merge_contents<W: Write + io::Seek>(
         &mut self,
@@ -890,6 +901,7 @@ const fn unsupported_zip_error<T>(detail: &'static str) -> ZipResult<T> {
 }
 
 /// Parse a central directory entry to collect the information for the file.
+#[cfg(feature = "std")]
 pub(crate) fn central_header_to_zip_file<R: Read + Seek>(
     reader: &mut R,
     archive_offset: u64,
@@ -906,6 +918,7 @@ pub(crate) fn central_header_to_zip_file<R: Read + Seek>(
 }
 
 /// Parse a central directory entry to collect the information for the file.
+#[cfg(feature = "std")]
 fn central_header_to_zip_file_inner<R: Read>(
     reader: &mut R,
     archive_offset: u64,
@@ -998,6 +1011,7 @@ fn central_header_to_zip_file_inner<R: Read>(
     Ok(result)
 }
 
+#[cfg(feature = "std")]
 fn parse_extra_field(file: &mut ZipFileData) -> ZipResult<()> {
     let Some(extra_field) = &file.extra_field else {
         return Ok(());
@@ -1088,6 +1102,7 @@ fn parse_extra_field(file: &mut ZipFileData) -> ZipResult<()> {
 }
 
 /// Methods for retrieving information on zip files
+#[cfg(feature = "std")]
 impl<'a> ZipFile<'a> {
     fn get_reader(&mut self) -> ZipResult<&mut ZipFileReader<'a>> {
         if let ZipFileReader::NoReader = self.reader {
@@ -1250,6 +1265,7 @@ impl<'a> ZipFile<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> Read for ZipFile<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.get_reader()?.read(buf)
@@ -1295,6 +1311,7 @@ impl<'a> Drop for ZipFile<'a> {
 /// * `comment`: set to an empty string
 /// * `data_start`: set to 0
 /// * `external_attributes`: `unix_mode()`: will return None
+#[cfg(feature = "std")]
 pub fn read_zipfile_from_stream<'a, R: Read>(reader: &'a mut R) -> ZipResult<Option<ZipFile<'_>>> {
     let signature = reader.read_u32_le()?;
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -25,6 +25,7 @@ pub struct CentralDirectoryEnd {
     pub zip_file_comment: Box<[u8]>,
 }
 
+#[cfg(feature = "std")]
 impl CentralDirectoryEnd {
     pub fn parse<T: Read>(reader: &mut T) -> ZipResult<CentralDirectoryEnd> {
         let magic = reader.read_u32_le()?;
@@ -112,6 +113,7 @@ pub struct Zip64CentralDirectoryEndLocator {
     pub number_of_disks: u32,
 }
 
+#[cfg(feature = "std")]
 impl Zip64CentralDirectoryEndLocator {
     pub fn parse<T: Read>(reader: &mut T) -> ZipResult<Zip64CentralDirectoryEndLocator> {
         let magic = reader.read_u32_le()?;
@@ -152,6 +154,8 @@ pub struct Zip64CentralDirectoryEnd {
     //pub extensible_data_sector: Vec<u8>, <-- We don't do anything with this at the moment.
 }
 
+
+#[cfg(feature = "std")]
 impl Zip64CentralDirectoryEnd {
     pub fn find_and_parse<T: Read + Seek>(
         reader: &mut T,

--- a/src/write.rs
+++ b/src/write.rs
@@ -52,6 +52,8 @@ enum MaybeEncrypted<W> {
     Aes(crate::aes::AesWriter<W>),
     ZipCrypto(crate::zipcrypto::ZipCryptoWriter<W>),
 }
+
+#[cfg(feature = "std")]
 impl<W: Write> Write for MaybeEncrypted<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self {
@@ -70,6 +72,7 @@ impl<W: Write> Write for MaybeEncrypted<W> {
         }
     }
 }
+#[cfg(feature = "std")]
 enum GenericZipWriter<W: Write + Seek> {
     Closed,
     Storer(MaybeEncrypted<W>),
@@ -90,6 +93,7 @@ enum GenericZipWriter<W: Write + Seek> {
 }
 
 // Put the struct declaration in a private module to convince rustdoc to display ZipWriter nicely
+#[cfg(feature = "std")]
 pub(crate) mod zip_writer {
     use super::*;
     /// ZIP archive generator
@@ -458,6 +462,7 @@ impl<'k, T: FileOptionExtension> Default for FileOptions<'k, T> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<W: Write + Seek> Write for ZipWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if !self.writing_to_file {
@@ -511,6 +516,7 @@ impl ZipWriterStats {
     }
 }
 
+#[cfg(feature = "std")]
 impl<A: Read + Write + Seek> ZipWriter<A> {
     /// Initializes the archive from an existing ZIP archive, making it ready for append.
     pub fn new_append(mut readwriter: A) -> ZipResult<ZipWriter<A>> {
@@ -546,6 +552,7 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<A: Read + Write + Seek> ZipWriter<A> {
     /// Adds another copy of a file already in this archive. This will produce a larger but more
     /// widely-compatible archive compared to [Self::shallow_copy_file]. Does not copy alignment.
@@ -671,6 +678,7 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<W: Write + Seek> ZipWriter<W> {
     /// Initializes the archive.
     ///
@@ -1475,6 +1483,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<W: Write + Seek> Drop for ZipWriter<W> {
     fn drop(&mut self) {
         if !self.inner.is_closed() {
@@ -1487,6 +1496,7 @@ impl<W: Write + Seek> Drop for ZipWriter<W> {
 
 type SwitchWriterFunction<W> = Box<dyn FnOnce(MaybeEncrypted<W>) -> GenericZipWriter<W>>;
 
+#[cfg(feature = "std")]
 impl<W: Write + Seek> GenericZipWriter<W> {
     fn prepare_next_writer(
         &self,
@@ -1731,6 +1741,7 @@ fn clamp_opt<T: Ord + Copy, U: Ord + Copy + TryFrom<T>>(
     }
 }
 
+#[cfg(feature = "std")]
 fn update_aes_extra_data<W: Write + io::Seek>(
     writer: &mut W,
     file: &mut ZipFileData,
@@ -1775,6 +1786,7 @@ fn update_aes_extra_data<W: Write + io::Seek>(
     Ok(())
 }
 
+#[cfg(feature = "std")]
 fn update_local_file_header<T: Write + Seek>(writer: &mut T, file: &ZipFileData) -> ZipResult<()> {
     const CRC32_OFFSET: u64 = 14;
     writer.seek(SeekFrom::Start(file.header_start + CRC32_OFFSET))?;
@@ -1796,6 +1808,7 @@ fn update_local_file_header<T: Write + Seek>(writer: &mut T, file: &ZipFileData)
     Ok(())
 }
 
+#[cfg(feature = "std")]
 fn write_central_directory_header<T: Write>(writer: &mut T, file: &ZipFileData) -> ZipResult<()> {
     // buffer zip64 extra field to determine its variable length
     let mut zip64_extra_field = [0; 28];
@@ -1895,6 +1908,7 @@ fn validate_extra_data(header_id: u16, data: &[u8]) -> ZipResult<()> {
     Ok(())
 }
 
+#[cfg(feature = "std")]
 fn write_local_zip64_extra_field<T: Write>(writer: &mut T, file: &ZipFileData) -> ZipResult<()> {
     // This entry in the Local header MUST include BOTH original
     // and compressed file size fields.
@@ -1907,6 +1921,7 @@ fn write_local_zip64_extra_field<T: Write>(writer: &mut T, file: &ZipFileData) -
     Ok(())
 }
 
+#[cfg(feature = "std")]
 fn update_local_zip64_extra_field<T: Write + Seek>(
     writer: &mut T,
     file: &ZipFileData,
@@ -1920,6 +1935,7 @@ fn update_local_zip64_extra_field<T: Write + Seek>(
     Ok(())
 }
 
+#[cfg(feature = "std")]
 fn write_central_zip64_extra_field<T: Write>(writer: &mut T, file: &ZipFileData) -> ZipResult<u16> {
     // The order of the fields in the zip64 extended
     // information record is fixed, but the fields MUST

--- a/src/zipcrypto.rs
+++ b/src/zipcrypto.rs
@@ -94,6 +94,7 @@ pub enum ZipCryptoValidator {
     InfoZipMsdosTime(u16),
 }
 
+#[cfg(feature = "std")]
 impl<R: std::io::Read> ZipCryptoReader<R> {
     /// Note: The password is `&[u8]` and not `&str` because the
     /// [zip specification](https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.3.TXT)
@@ -147,12 +148,15 @@ impl<R: std::io::Read> ZipCryptoReader<R> {
         Ok(ZipCryptoReaderValid { reader: self })
     }
 }
+
 #[allow(unused)]
 pub(crate) struct ZipCryptoWriter<W> {
     pub(crate) writer: W,
     pub(crate) buffer: Vec<u8>,
     pub(crate) keys: ZipCryptoKeys,
 }
+
+#[cfg(feature = "std")]
 impl<W: std::io::Write> ZipCryptoWriter<W> {
     #[allow(unused)]
     pub(crate) fn finish(mut self, crc32: u32) -> std::io::Result<W> {
@@ -180,6 +184,7 @@ pub struct ZipCryptoReaderValid<R> {
     reader: ZipCryptoReader<R>,
 }
 
+#[cfg(feature = "std")]
 impl<R: std::io::Read> std::io::Read for ZipCryptoReaderValid<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         // Note: There might be potential for optimization. Inspiration can be found at:
@@ -193,6 +198,7 @@ impl<R: std::io::Read> std::io::Read for ZipCryptoReaderValid<R> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<R: std::io::Read> ZipCryptoReaderValid<R> {
     /// Consumes this decoder, returning the underlying reader.
     pub fn into_inner(self) -> R {


### PR DESCRIPTION
<!-- 
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Please make sure your PR's target repo is `zip-rs/zip2` and not `zip-rs/zip-old`. The latter
  repo is no longer maintained, and I will archive it after closing the pre-existing issues.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- Commit messages and the PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start 
  with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
- All commits must be signed and display a "Verified" badge; see 
  https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification.
  If any of your commits don't have a "Verified" badge, here's how to fix this:
  1. Generate a GPG key if you don't already have one, by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key.
  2. If you use GitHub's email privacy feature, associate the key with your users.noreply.github.com email address by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/associating-an-email-with-your-gpg-key.
  3. Configure Git to use your signing key by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key
  4. Add the key to your GitHub account by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account
  5. Enable commit signing by following
     https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
  6. Squash your PR into one commit or run `git commit --amend --no-edit`, because enabling commit signing isn't retroactive
     even for unpushed commits.

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->
impl a "std" feature to allow the reuse of structs or enums that don't require any use of std::io::Read/Seek/Write and when implementing tokio/rayon it allows to reuse these structures and it's functions names without conflict.