### PR TITLE
fix CI with platform-dependent string encoding

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -13,12 +13,17 @@ use crate::types::{AesMode, AesVendorVersion, DateTime, System, ZipFileData};
 use crate::zipcrypto::{ZipCryptoReader, ZipCryptoReaderValid, ZipCryptoValidator};
 use indexmap::IndexMap;
 use std::borrow::Cow;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::fs::create_dir_all;
 use std::io::{self, copy, prelude::*, sink};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStringExt;
 
 #[cfg(any(
     feature = "deflate",
@@ -686,10 +691,28 @@ impl<R: Read + Seek> ZipArchive<R> {
                 if let Some(p) = outpath.parent() {
                     Self::make_writable_dir_all(p)?;
                 }
+                /* FIXME: what bug does this code fix?
+                 * https://github.com/zip-rs/zip2/commit/8715d936cbd3e0fdc2e778b70d8a02e2dfc16fc2
+                 * doesn't specify! */
                 if file.is_symlink() && (cfg!(unix) || cfg!(windows)) {
                     let mut target = Vec::with_capacity(file.size() as usize);
                     file.read_exact(&mut target)?;
-                    let target_path: PathBuf = directory.as_ref().join(OsString::try_from(target)?);
+                    #[cfg(unix)]
+                    let target_str = OsString::from_vec(target);
+                    #[cfg(windows)]
+                    let target_str: OsString = {
+                        let chunks = target.chunks_exact(2);
+                        assert!(
+                            chunks.remainder().is_empty(),
+                            "windows utf-16 strings should be divisible by 2"
+                        );
+                        let target_wide: Vec<u16> = chunks
+                            .into_iter()
+                            .map(|c| u16::from_le_bytes(c.try_into().unwrap()))
+                            .collect();
+                        OsString::from_wide(&target_wide)
+                    };
+                    let target_path: PathBuf = directory.as_ref().join(target_str);
                     #[cfg(unix)]
                     {
                         std::os::unix::fs::symlink(target_path, outpath.as_path())?;

--- a/tests/repro_old423.rs
+++ b/tests/repro_old423.rs
@@ -1,9 +1,8 @@
-use tempdir::TempDir;
-
 #[cfg(all(unix, feature = "_deflate-any"))]
 #[test]
 fn repro_old423() -> zip::result::ZipResult<()> {
     use std::io;
+    use tempdir::TempDir;
     use zip::ZipArchive;
 
     let mut v = Vec::new();


### PR DESCRIPTION
This fixes the CI failure introduced in https://github.com/zip-rs/zip2/commit/8715d936cbd3e0fdc2e778b70d8a02e2dfc16fc2, as there appears to be no platform-independent way to create an `OsString` (see links in docstring for [`OsString::from_encoded_bytes_unchecked()`](https://doc.rust-lang.org/std/ffi/struct.OsString.html#method.from_encoded_bytes_unchecked)). This is causing a [failure](
https://github.com/zip-rs/zip2/actions/runs/9085755853/job/24969824813) on master.

This also fixes an additional compile error in a test file that only shows up with specific features enabled.