### PR TITLE
use cfg-if! macro to clarify conditional compilation sections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ time = { version = "0.3.36", default-features = false }
 [dependencies]
 aes = { version = "0.8.4", optional = true }
 bzip2 = { version = "0.4.4", optional = true }
+cfg-if = "1"
 chrono = { version = "0.4.38", optional = true }
 constant_time_eq = { version = "0.3.0", optional = true }
 crc32fast = "1.4.0"

--- a/benches/merge_archive.rs
+++ b/benches/merge_archive.rs
@@ -112,20 +112,22 @@ fn merge_archive_raw_copy_file_compressed(bench: &mut Bencher) {
     });
 }
 
-#[cfg(feature = "_deflate-any")]
-benchmark_group!(
-    benches,
-    merge_archive_stored,
-    merge_archive_compressed,
-    merge_archive_raw_copy_file_stored,
-    merge_archive_raw_copy_file_compressed,
-);
-
-#[cfg(not(feature = "_deflate-any"))]
-benchmark_group!(
-    benches,
-    merge_archive_stored,
-    merge_archive_raw_copy_file_stored,
-);
+cfg_if::cfg_if! {
+    if #[cfg(feature = "_deflate-any")] {
+        benchmark_group!(
+            benches,
+            merge_archive_stored,
+            merge_archive_compressed,
+            merge_archive_raw_copy_file_stored,
+            merge_archive_raw_copy_file_compressed,
+        );
+    } else {
+        benchmark_group!(
+            benches,
+            merge_archive_stored,
+            merge_archive_raw_copy_file_stored,
+        );
+    }
+}
 
 benchmark_main!(benches);

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -1,6 +1,7 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 use anyhow::Context;
+use cfg_if::cfg_if;
 use clap::{Parser, ValueEnum};
 use std::io::prelude::*;
 use zip::{result::ZipError, write::SimpleFileOptions};
@@ -37,20 +38,30 @@ fn main() {
 
 const METHOD_STORED: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Stored);
 
-#[cfg(feature = "_deflate-any")]
-const METHOD_DEFLATED: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Deflated);
-#[cfg(not(feature = "_deflate-any"))]
-const METHOD_DEFLATED: Option<zip::CompressionMethod> = None;
+cfg_if! {
+    if #[cfg(feature = "_deflate-any")] {
+        const METHOD_DEFLATED: Option<zip::CompressionMethod> =
+            Some(zip::CompressionMethod::Deflated);
+    } else {
+        const METHOD_DEFLATED: Option<zip::CompressionMethod> = None;
+    }
+}
 
-#[cfg(feature = "bzip2")]
-const METHOD_BZIP2: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Bzip2);
-#[cfg(not(feature = "bzip2"))]
-const METHOD_BZIP2: Option<zip::CompressionMethod> = None;
+cfg_if! {
+    if #[cfg(feature = "bzip2")] {
+        const METHOD_BZIP2: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Bzip2);
+    } else {
+        const METHOD_BZIP2: Option<zip::CompressionMethod> = None;
+    }
+}
 
-#[cfg(feature = "zstd")]
-const METHOD_ZSTD: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Zstd);
-#[cfg(not(feature = "zstd"))]
-const METHOD_ZSTD: Option<zip::CompressionMethod> = None;
+cfg_if! {
+    if #[cfg(feature = "zstd")] {
+        const METHOD_ZSTD: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Zstd);
+    } else {
+        const METHOD_ZSTD: Option<zip::CompressionMethod> = None;
+    }
+}
 
 fn real_main() -> i32 {
     let args = Args::parse();
@@ -59,49 +70,54 @@ fn real_main() -> i32 {
     let method = match args.compression_method {
         CompressionMethod::Stored => zip::CompressionMethod::Stored,
         CompressionMethod::Deflated => {
-            #[cfg(not(feature = "deflate"))]
-            {
-                println!("The `deflate` feature is not enabled");
-                return 1;
+            cfg_if! {
+                if #[cfg(feature = "deflate")] {
+                    zip::CompressionMethod::Deflated
+                } else {
+                    println!("The `deflate` feature is not enabled");
+                    return 1;
+                }
             }
-            #[cfg(feature = "deflate")]
-            zip::CompressionMethod::Deflated
         }
         CompressionMethod::DeflatedMiniz => {
-            #[cfg(not(feature = "deflate-miniz"))]
-            {
-                println!("The `deflate-miniz` feature is not enabled");
-                return 1;
+            cfg_if! {
+                if #[cfg(feature = "deflate-miniz")] {
+                    zip::CompressionMethod::Deflated
+                } else {
+                    println!("The `deflate-miniz` feature is not enabled");
+                    return 1;
+                }
             }
-            #[cfg(feature = "deflate-miniz")]
-            zip::CompressionMethod::Deflated
         }
         CompressionMethod::DeflatedZlib => {
-            #[cfg(not(feature = "deflate-zlib"))]
-            {
-                println!("The `deflate-zlib` feature is not enabled");
-                return 1;
+            cfg_if! {
+                if #[cfg(feature = "deflate-zlib")] {
+                    zip::CompressionMethod::Deflated
+                } else {
+                    println!("The `deflate-zlib` feature is not enabled");
+                    return 1;
+                }
             }
-            #[cfg(feature = "deflate-zlib")]
-            zip::CompressionMethod::Deflated
         }
         CompressionMethod::Bzip2 => {
-            #[cfg(not(feature = "bzip2"))]
-            {
-                println!("The `bzip2` feature is not enabled");
-                return 1;
+            cfg_if! {
+                if #[cfg(feature = "bzip2")] {
+                    zip::CompressionMethod::Bzip2
+                } else {
+                    println!("The `bzip2` feature is not enabled");
+                    return 1;
+                }
             }
-            #[cfg(feature = "bzip2")]
-            zip::CompressionMethod::Bzip2
         }
         CompressionMethod::Zstd => {
-            #[cfg(not(feature = "zstd"))]
-            {
-                println!("The `zstd` feature is not enabled");
-                return 1;
+            cfg_if! {
+                if #[cfg(feature = "zstd")] {
+                    zip::CompressionMethod::Zstd
+                } else {
+                    println!("The `zstd` feature is not enabled");
+                    return 1;
+                }
             }
-            #[cfg(feature = "zstd")]
-            zip::CompressionMethod::Zstd
         }
     };
     match doit(src_dir, dst_file, method) {

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use cfg_if::cfg_if;
+
 #[allow(deprecated)]
 /// Identifies the storage format used to compress a file within a ZIP archive.
 ///
@@ -55,39 +57,57 @@ impl CompressionMethod {
     pub const REDUCE_3: Self = CompressionMethod::Unsupported(4);
     pub const REDUCE_4: Self = CompressionMethod::Unsupported(5);
     pub const IMPLODE: Self = CompressionMethod::Unsupported(6);
-    #[cfg(feature = "_deflate-any")]
-    pub const DEFLATE: Self = CompressionMethod::Deflated;
-    #[cfg(not(feature = "_deflate-any"))]
-    pub const DEFLATE: Self = CompressionMethod::Unsupported(8);
-    #[cfg(feature = "deflate64")]
-    pub const DEFLATE64: Self = CompressionMethod::Deflate64;
-    #[cfg(not(feature = "deflate64"))]
-    pub const DEFLATE64: Self = CompressionMethod::Unsupported(9);
+    cfg_if! {
+        if #[cfg(feature = "_deflate-any")] {
+            pub const DEFLATE: Self = CompressionMethod::Deflated;
+        } else {
+            pub const DEFLATE: Self = CompressionMethod::Unsupported(8);
+        }
+    }
+    cfg_if! {
+        if #[cfg(feature = "deflate64")] {
+            pub const DEFLATE64: Self = CompressionMethod::Deflate64;
+        } else {
+            pub const DEFLATE64: Self = CompressionMethod::Unsupported(9);
+        }
+    }
     pub const PKWARE_IMPLODE: Self = CompressionMethod::Unsupported(10);
-    #[cfg(feature = "bzip2")]
-    pub const BZIP2: Self = CompressionMethod::Bzip2;
-    #[cfg(not(feature = "bzip2"))]
-    pub const BZIP2: Self = CompressionMethod::Unsupported(12);
-    #[cfg(not(feature = "lzma"))]
-    pub const LZMA: Self = CompressionMethod::Unsupported(14);
-    #[cfg(feature = "lzma")]
-    pub const LZMA: Self = CompressionMethod::Lzma;
+    cfg_if! {
+        if #[cfg(feature = "bzip2")] {
+            pub const BZIP2: Self = CompressionMethod::Bzip2;
+        } else {
+            pub const BZIP2: Self = CompressionMethod::Unsupported(12);
+        }
+    }
+    cfg_if! {
+        if #[cfg(feature = "lzma")] {
+            pub const LZMA: Self = CompressionMethod::Lzma;
+        } else {
+            pub const LZMA: Self = CompressionMethod::Unsupported(14);
+        }
+    }
     pub const IBM_ZOS_CMPSC: Self = CompressionMethod::Unsupported(16);
     pub const IBM_TERSE: Self = CompressionMethod::Unsupported(18);
     pub const ZSTD_DEPRECATED: Self = CompressionMethod::Unsupported(20);
-    #[cfg(feature = "zstd")]
-    pub const ZSTD: Self = CompressionMethod::Zstd;
-    #[cfg(not(feature = "zstd"))]
-    pub const ZSTD: Self = CompressionMethod::Unsupported(93);
+    cfg_if! {
+        if #[cfg(feature = "zstd")] {
+            pub const ZSTD: Self = CompressionMethod::Zstd;
+        } else {
+            pub const ZSTD: Self = CompressionMethod::Unsupported(93);
+        }
+    }
     pub const MP3: Self = CompressionMethod::Unsupported(94);
     pub const XZ: Self = CompressionMethod::Unsupported(95);
     pub const JPEG: Self = CompressionMethod::Unsupported(96);
     pub const WAVPACK: Self = CompressionMethod::Unsupported(97);
     pub const PPMD: Self = CompressionMethod::Unsupported(98);
-    #[cfg(feature = "aes-crypto")]
-    pub const AES: Self = CompressionMethod::Aes;
-    #[cfg(not(feature = "aes-crypto"))]
-    pub const AES: Self = CompressionMethod::Unsupported(99);
+    cfg_if! {
+        if #[cfg(feature = "aes-crypto")] {
+            pub const AES: Self = CompressionMethod::Aes;
+        } else {
+            pub const AES: Self = CompressionMethod::Unsupported(99);
+        }
+    }
 }
 impl CompressionMethod {
     /// Converts an u16 to its corresponding CompressionMethod
@@ -145,11 +165,13 @@ impl CompressionMethod {
 
 impl Default for CompressionMethod {
     fn default() -> Self {
-        #[cfg(feature = "_deflate-any")]
-        return CompressionMethod::Deflated;
-
-        #[cfg(not(feature = "_deflate-any"))]
-        return CompressionMethod::Stored;
+        cfg_if! {
+            if #[cfg(feature = "_deflate-any")] {
+                CompressionMethod::Deflated
+            } else {
+                CompressionMethod::Stored
+            }
+        }
     }
 }
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -12,14 +12,16 @@ use cfg_if::cfg_if;
 ///
 /// When creating ZIP files, you may choose the method to use with
 /// [`crate::write::FileOptions::compression_method`]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 #[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum CompressionMethod {
     /// Store the file as is
+    #[cfg_attr(not(feature = "_deflate-any"), default)]
     Stored,
     /// Compress the file using Deflate
     #[cfg(feature = "_deflate-any")]
+    #[default]
     Deflated,
     /// Compress the file using Deflate64.
     /// Decoding deflate64 is supported but encoding deflate64 is not supported.
@@ -159,18 +161,6 @@ impl CompressionMethod {
             CompressionMethod::Lzma => 14,
 
             CompressionMethod::Unsupported(v) => v,
-        }
-    }
-}
-
-impl Default for CompressionMethod {
-    fn default() -> Self {
-        cfg_if! {
-            if #[cfg(feature = "_deflate-any")] {
-                CompressionMethod::Deflated
-            } else {
-                CompressionMethod::Stored
-            }
         }
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -441,13 +441,17 @@ impl<'k> FileOptions<'k, ExtendedFileOptions> {
 impl<'k, T: FileOptionExtension> Default for FileOptions<'k, T> {
     /// Construct a new FileOptions object
     fn default() -> Self {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "time")] {
+                let last_modified_time = OffsetDateTime::now_utc().try_into().unwrap_or_default();
+            } else {
+                let last_modified_time = DateTime::default();
+            }
+        }
         Self {
             compression_method: Default::default(),
             compression_level: None,
-            #[cfg(feature = "time")]
-            last_modified_time: OffsetDateTime::now_utc().try_into().unwrap_or_default(),
-            #[cfg(not(feature = "time"))]
-            last_modified_time: DateTime::default(),
+            last_modified_time,
             permissions: None,
             large_file: false,
             encrypt_with: None,

--- a/src/zipcrypto.rs
+++ b/src/zipcrypto.rs
@@ -21,19 +21,20 @@ pub(crate) struct ZipCryptoKeys {
 impl Debug for ZipCryptoKeys {
     #[allow(unreachable_code)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        #[cfg(not(any(test, fuzzing)))]
-        {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::Hasher;
-            let mut t = DefaultHasher::new();
-            self.hash(&mut t);
-            return f.write_fmt(format_args!("ZipCryptoKeys(hash {})", t.finish()));
+        cfg_if::cfg_if! {
+            if #[cfg(any(test, fuzzing))] {
+                f.write_fmt(format_args!(
+                    "ZipCryptoKeys({:#10x},{:#10x},{:#10x})",
+                    self.key_0, self.key_1, self.key_2
+                ))
+            } else {
+                use std::collections::hash_map::DefaultHasher;
+                use std::hash::Hasher;
+                let mut t = DefaultHasher::new();
+                self.hash(&mut t);
+                f.write_fmt(format_args!("ZipCryptoKeys(hash {})", t.finish()))
+            }
         }
-        #[cfg(any(test, fuzzing))]
-        return f.write_fmt(format_args!(
-            "ZipCryptoKeys({:#10x},{:#10x},{:#10x})",
-            self.key_0, self.key_1, self.key_2
-        ));
     }
 }
 

--- a/tests/repro_old423.rs
+++ b/tests/repro_old423.rs
@@ -1,9 +1,8 @@
-use tempdir::TempDir;
-
 #[cfg(all(unix, feature = "_deflate-any"))]
 #[test]
 fn repro_old423() -> zip::result::ZipResult<()> {
     use std::io;
+    use tempdir::TempDir;
     use zip::ZipArchive;
 
     let mut v = Vec::new();


### PR DESCRIPTION
As noted in https://github.com/zip-rs/zip2/pull/125#issuecomment-2112950347, the [`cfg-if`](https://docs.rs/cfg-if) crate can be helpful for complex conditional compilation (like that introduced in #125). I believe I had made this change in the previous zip repo, but hadn't pushed it. This should produce no change in compiled output compared to the previous `#[cfg(...)] { ... }` blocks.