### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [1.3.0](https://github.com/zip-rs/zip2/compare/v1.2.3...v1.3.0) - 2024-05-17
+
+### <!-- 0 -->🚀 Features
+- Add `is_symlink` method
+
+### <!-- 1 -->🐛 Bug Fixes
+- Extract symlinks into symlinks on Unix and Windows, and fix a bug that affected making directories writable on MacOS
+
+### <!-- 2 -->🚜 Refactor
+- Eliminate deprecation warning when `--all-features` implicitly enables the deprecated feature
+- Check if archive contains a symlink's target, without borrowing both at the same time
+- Eliminate a clone that's no longer necessary
+- is_dir only needs to look at the filename
+- Remove unnecessary #[cfg] attributes
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+- Fix borrow-of-moved-value
+- Box<str> doesn't directly convert to PathBuf, so convert back to String first
+- partial revert - only &str has chars(), but Box<str> should auto-deref
+- contains_key needs a `Box<str>`, so generify `is_dir` to accept one
+- Add missing `ZipFileData::is_dir()` method
+- Fix another Windows-specific error
+- More bug fixes for Windows-specific symlink code
+- More bug fixes for Windows-specific symlink code
+- Bug fix: variable name change
+- Bug fix: need both internal and output path to determine whether to symlink_dir
+- Another bug fix
+- Fix another error-type conversion error
+- Fix error-type conversion on Windows
+- Fix conditionally-unused import
+- Fix continued issues, and factor out the Vec<u8>-to-OsString conversion (cc: [#125](https://github.com/zip-rs/zip2/pull/125))
+- Fix CI failure involving conversion to OsString for symlinks (see my comments on [#125](https://github.com/zip-rs/zip2/pull/125))
+- Move path join into platform-independent code
+
 ## [1.2.3](https://github.com/zip-rs/zip2/compare/v1.2.2...v1.2.3) - 2024-05-10
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "1.2.3"
+version = "1.3.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION
## 🤖 New release
* `zip`: 1.2.3 -> 1.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.0](https://github.com/zip-rs/zip2/compare/v1.2.3...v1.3.0) - 2024-05-17

### <!-- 0 -->🚀 Features
- Add `is_symlink` method

### <!-- 1 -->🐛 Bug Fixes
- Extract symlinks into symlinks on Unix and Windows, and fix a bug that affected making directories writable on MacOS

### <!-- 2 -->🚜 Refactor
- Eliminate deprecation warning when `--all-features` implicitly enables the deprecated feature
- Check if archive contains a symlink's target, without borrowing both at the same time
- Eliminate a clone that's no longer necessary
- is_dir only needs to look at the filename
- Remove unnecessary #[cfg] attributes

### <!-- 7 -->⚙️ Miscellaneous Tasks
- Fix borrow-of-moved-value
- Box<str> doesn't directly convert to PathBuf, so convert back to String first
- partial revert - only &str has chars(), but Box<str> should auto-deref
- contains_key needs a `Box<str>`, so generify `is_dir` to accept one
- Add missing `ZipFileData::is_dir()` method
- Fix another Windows-specific error
- More bug fixes for Windows-specific symlink code
- More bug fixes for Windows-specific symlink code
- Bug fix: variable name change
- Bug fix: need both internal and output path to determine whether to symlink_dir
- Another bug fix
- Fix another error-type conversion error
- Fix error-type conversion on Windows
- Fix conditionally-unused import
- Fix continued issues, and factor out the Vec<u8>-to-OsString conversion (cc: [#125](https://github.com/zip-rs/zip2/pull/125))
- Fix CI failure involving conversion to OsString for symlinks (see my comments on [#125](https://github.com/zip-rs/zip2/pull/125))
- Move path join into platform-independent code
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).