### PR TITLE
docs: Enable `doc_auto_cfg` feature with Docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,23 @@ edition = "2021"
 exclude = ["tests/**", "examples/**", ".github/**", "fuzz/**"]
 build = "src/build.rs"
 
+[package.metadata.docs.rs]
+features = [
+    "aes-crypto",
+    "bzip2",
+    "chrono",
+    "deflate",
+    "deflate64",
+    "deflate-zlib-ng",
+    "lzma",
+    "time",
+    "zstd",
+]
+# Can be enabled when <https://github.com/zopfli-rs/zopfli/issues/42> is fixed
+# all-features = true
+no-default-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [workspace.dependencies]
 time = { version = "0.3.36", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ features = [
     "chrono",
     "deflate",
     "deflate64",
+    "deflate",
+    "deflate-zlib",
     "deflate-zlib-ng",
     "lzma",
     "time",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! | ZipCrypto deprecated encryption | ✅ | ✅ |
 //!
 //!
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 #![allow(unexpected_cfgs)] // Needed for cfg(fuzzing) on nightly as of 2024-05-06
 pub use crate::compression::{CompressionMethod, SUPPORTED_COMPRESSION_METHODS};


### PR DESCRIPTION
Currently, the  documentation cannot be built when the `deflate-zopfli` feature is enabled (see <https://github.com/zopfli-rs/zopfli/issues/42>). So I think when this issue is resolved it will be possible to build the  documentation with `all-features = true`.

To reproduce locally:

```sh
env RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -F "aes-crypto bzip2 chrono deflate deflate64 deflate-zlib-ng lzma time zstd" --no-default-features
```

Screenshots:

![DateTime](https://github.com/zip-rs/zip2/assets/48999343/09ac2d1c-d255-4901-beca-5d3c034111db)
![CompressionMethod](https://github.com/zip-rs/zip2/assets/48999343/d429c1ae-42f2-4ed9-9418-250a4b347c22)
