### PR TITLE
doc: Enable all features for Docs.rs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
         - rustalias: stable
           rust: stable
         - rustalias: msrv
-          rust: '1.70'
+          rust: '1.73'
         - rustalias: nightly
           rust: nightly
     name: 'Build and test ${{ matrix.feature_flag }}: ${{ matrix.os }}, ${{ matrix.rustalias }}'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 license = "MIT"
 repository = "https://github.com/zip-rs/zip2.git"
 keywords = ["zip", "archive", "compression"]
-rust-version = "1.70.0"
+rust-version = "1.73.0"
 description = """
 Library to support the reading and writing of zip files.
 """
@@ -19,22 +19,7 @@ exclude = ["tests/**", "examples/**", ".github/**", "fuzz/**"]
 build = "src/build.rs"
 
 [package.metadata.docs.rs]
-features = [
-    "aes-crypto",
-    "bzip2",
-    "chrono",
-    "deflate",
-    "deflate64",
-    "deflate",
-    "deflate-zlib",
-    "deflate-zlib-ng",
-    "lzma",
-    "time",
-    "zstd",
-]
-# Can be enabled when <https://github.com/zopfli-rs/zopfli/issues/42> is fixed
-# all-features = true
-no-default-features = true
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
@@ -59,7 +44,7 @@ time = { workspace = true, optional = true, features = [
 ] }
 zeroize = { version = "1.6.0", optional = true, features = ["zeroize_derive"] }
 zstd = { version = "0.13.1", optional = true, default-features = false }
-zopfli = { version = "0.8.0", optional = true }
+zopfli = { version = "0.8.1", optional = true }
 deflate64 = { version = "0.1.8", optional = true }
 lzma-rs = { version = "0.3.0", default-features = false, optional = true }
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The following feature flags are deprecated:
 MSRV
 ----
 
-Our current Minimum Supported Rust Version is **1.70**. When adding features,
+Our current Minimum Supported Rust Version is **1.73**. When adding features,
 we will follow these guidelines:
 
 - We will always support the latest four minor Rust versions. This gives you a 6


### PR DESCRIPTION
zopfli-rs/zopfli#42 was resolved in `zopfli` v0.8.1, so I enabled all features for Docs.rs. I also changed the MSV to v1.73.0, because the MSRV of `zopfli` v0.8.1 is v1.73.0. This is older than the latest 4 minor Rust versions,[^1] so this MSRV change seems fine.

[^1]: <https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html>