### PR TITLE
chore: release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.3.1](https://github.com/zip-rs/zip2/compare/v1.3.0...v1.3.1) - 2024-05-21
+
+### <!-- 2 -->🚜 Refactor
+- Make `deflate` enable both default implementations
+- Merge the hidden deflate-flate2 flag into the public one
+- Rename _deflate-non-zopfli to _deflate-flate2
+- Reject encrypted and using_data_descriptor files slightly faster in read_zipfile_from_stream
+- Convert `impl TryInto<NaiveDateTime> for DateTime` to `impl TryFrom<DateTime> for NaiveDateTime` ([#136](https://github.com/zip-rs/zip2/pull/136))
+
+### <!-- 4 -->⚡ Performance
+- Change default compression implementation to `flate2/zlib-ng`
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+- chore([#132](https://github.com/zip-rs/zip2/pull/132)): Attribution for some copied test data
+- chore([#133](https://github.com/zip-rs/zip2/pull/133)): chmod -x src/result.rs
+
 ## [1.3.0](https://github.com/zip-rs/zip2/compare/v1.2.3...v1.3.0) - 2024-05-17
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION
## 🤖 New release
* `zip`: 1.3.0 -> 1.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.1](https://github.com/zip-rs/zip2/compare/v1.3.0...v1.3.1) - 2024-05-21

### <!-- 2 -->🚜 Refactor
- Make `deflate` enable both default implementations
- Merge the hidden deflate-flate2 flag into the public one
- Rename _deflate-non-zopfli to _deflate-flate2
- Reject encrypted and using_data_descriptor files slightly faster in read_zipfile_from_stream
- Convert `impl TryInto<NaiveDateTime> for DateTime` to `impl TryFrom<DateTime> for NaiveDateTime` ([#136](https://github.com/zip-rs/zip2/pull/136))

### <!-- 4 -->⚡ Performance
- Change default compression implementation to `flate2/zlib-ng`

### <!-- 7 -->⚙️ Miscellaneous Tasks
- chore([#132](https://github.com/zip-rs/zip2/pull/132)): Attribution for some copied test data
- chore([#133](https://github.com/zip-rs/zip2/pull/133)): chmod -x src/result.rs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).