### PR TITLE
feat: Expose AES information

### DIFF
--- a/src/aes.rs
+++ b/src/aes.rs
@@ -125,12 +125,12 @@ impl<R: Read> AesReader<R> {
         })
     }
 
-    /// Read the AES header bytes and returns the key and salt.
+    /// Read the AES header bytes and returns the verification value and salt.
     ///
     /// # Returns
     ///
-    /// the key and the salt
-    pub fn get_key_and_salt(mut self) -> io::Result<(Vec<u8>, Vec<u8>)> {
+    /// the verification value and the salt
+    pub fn get_verification_value_and_salt(mut self) -> io::Result<(Vec<u8>, Vec<u8>)> {
         let salt_length = self.aes_mode.salt_length();
 
         let mut salt = vec![0; salt_length];

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -15,7 +15,7 @@ use std::io::{self, Error, ErrorKind, Read, Write};
 use zeroize::{Zeroize, Zeroizing};
 
 /// The length of the password verifcation value in bytes
-const PWD_VERIFY_LENGTH: usize = 2;
+pub const PWD_VERIFY_LENGTH: usize = 2;
 /// The length of the authentication code in bytes
 const AUTH_CODE_LENGTH: usize = 10;
 /// The number of iterations used with PBKDF2
@@ -130,14 +130,16 @@ impl<R: Read> AesReader<R> {
     /// # Returns
     ///
     /// the verification value and the salt
-    pub fn get_verification_value_and_salt(mut self) -> io::Result<(Vec<u8>, Vec<u8>)> {
+    pub fn get_verification_value_and_salt(
+        mut self,
+    ) -> io::Result<([u8; PWD_VERIFY_LENGTH], Vec<u8>)> {
         let salt_length = self.aes_mode.salt_length();
 
         let mut salt = vec![0; salt_length];
         self.reader.read_exact(&mut salt)?;
 
         // next are 2 bytes used for password verification
-        let mut pwd_verification_value = vec![0; PWD_VERIFY_LENGTH];
+        let mut pwd_verification_value = [0; PWD_VERIFY_LENGTH];
         self.reader.read_exact(&mut pwd_verification_value)?;
         Ok((pwd_verification_value, salt))
     }

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -124,6 +124,23 @@ impl<R: Read> AesReader<R> {
             finalized: false,
         })
     }
+
+    /// Read the AES header bytes and returns the key and salt.
+    ///
+    /// # Returns
+    ///
+    /// the key and the salt
+    pub fn get_key_and_salt(mut self) -> io::Result<(Vec<u8>, Vec<u8>)> {
+        let salt_length = self.aes_mode.salt_length();
+
+        let mut salt = vec![0; salt_length];
+        self.reader.read_exact(&mut salt)?;
+
+        // next are 2 bytes used for password verification
+        let mut pwd_verification_value = vec![0; PWD_VERIFY_LENGTH];
+        self.reader.read_exact(&mut pwd_verification_value)?;
+        Ok((pwd_verification_value, salt))
+    }
 }
 
 /// A reader for aes encrypted files, which has already passed the first password check.

--- a/src/read.rs
+++ b/src/read.rs
@@ -82,6 +82,7 @@ pub(crate) mod zip_archive {
     }
 }
 
+#[cfg(feature = "aes-crypto")]
 use crate::aes::PWD_VERIFY_LENGTH;
 #[cfg(feature = "lzma")]
 use crate::read::lzma::LzmaDecoder;

--- a/src/read.rs
+++ b/src/read.rs
@@ -976,6 +976,7 @@ impl<R: Read + Seek> ZipArchive<R> {
 
 /// Holds the AES information of a file in the zip archive
 #[derive(Debug)]
+#[cfg(feature = "aes-crypto")]
 pub struct AesInfo {
     /// The AES encryption mode
     pub aes_mode: AesMode,

--- a/src/result.rs
+++ b/src/result.rs
@@ -46,10 +46,6 @@ impl ZipError {
     /// # ()
     /// ```
     pub const PASSWORD_REQUIRED: &'static str = "Password required to decrypt file";
-
-
-    /// The text used as an error when the archive is not encrypted
-    pub const ARCHIVE_NOT_ENCRYPTED: &'static str = "the archive is not encrypted";
 }
 
 impl From<ZipError> for io::Error {

--- a/src/result.rs
+++ b/src/result.rs
@@ -46,6 +46,10 @@ impl ZipError {
     /// # ()
     /// ```
     pub const PASSWORD_REQUIRED: &'static str = "Password required to decrypt file";
+
+
+    /// The text used as an error when the archive is not encrypted
+    pub const ARCHIVE_NOT_ENCRYPTED: &'static str = "the archive is not encrypted";
 }
 
 impl From<ZipError> for io::Error {


### PR DESCRIPTION
This PR adds helper functions to enable users to access AES information for encrypted files.

context: I need this for https://github.com/agourlay/zip-password-finder where I used to have a fork of the previous zip repository just for those. Now seems like a good time to get off my fork :)