### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.0.0](https://github.com/zip-rs/zip2/compare/v1.3.1...v2.0.0) - 2024-05-24
+
+### <!-- 0 -->🚀 Features
+- Add `fmt::Display` for `DateTime`
+- Implement more traits for `DateTime`
+
+### <!-- 2 -->🚜 Refactor
+- Change type of `last_modified_time` to `Option<DateTime>`
+- [**breaking**] Rename `from_msdos` to `from_msdos_unchecked`, make it unsafe, and add `try_from_msdos` ([#145](https://github.com/zip-rs/zip2/pull/145))
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+- Continue to accept archives with invalid DateTime, and use `now_utc()` as default only when writing, not reading
+
 ## [1.3.1](https://github.com/zip-rs/zip2/compare/v1.3.0...v1.3.1) - 2024-05-21
 
 ### <!-- 2 -->🚜 Refactor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "1.3.1"
+version = "2.0.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION
## 🤖 New release
* `zip`: 1.3.1 -> 2.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/zip-rs/zip2/compare/v1.3.1...v2.0.0) - 2024-05-24

### <!-- 0 -->🚀 Features
- Add `fmt::Display` for `DateTime`
- Implement more traits for `DateTime`

### <!-- 2 -->🚜 Refactor
- Change type of `last_modified_time` to `Option<DateTime>`
- [**breaking**] Rename `from_msdos` to `from_msdos_unchecked`, make it unsafe, and add `try_from_msdos` ([#145](https://github.com/zip-rs/zip2/pull/145))

### <!-- 7 -->⚙️ Miscellaneous Tasks
- Continue to accept archives with invalid DateTime, and use `now_utc()` as default only when writing, not reading
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).