### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.1.0](https://github.com/zip-rs/zip2/compare/v2.0.0...v2.1.0) - 2024-05-25
+
+### <!-- 0 -->🚀 Features
+- Support mutual conversion between `DateTime` and MS-DOS pair
+
+### <!-- 1 -->🐛 Bug Fixes
+- version-needed-to-extract was incorrect in central header, and version-made-by could be lower than that ([#100](https://github.com/zip-rs/zip2/pull/100))
+- version-needed-to-extract was incorrect in central header, and version-made-by could be lower than that ([#100](https://github.com/zip-rs/zip2/pull/100))
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+- Tweaks to make `version_needed` and `version_made_by` work with recently-merged changes
+
 ## [2.0.0](https://github.com/zip-rs/zip2/compare/v1.3.1...v2.0.0) - 2024-05-24
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION
## 🤖 New release
* `zip`: 2.0.0 -> 2.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.0](https://github.com/zip-rs/zip2/compare/v2.0.0...v2.1.0) - 2024-05-25

### <!-- 0 -->🚀 Features
- Support mutual conversion between `DateTime` and MS-DOS pair

### <!-- 1 -->🐛 Bug Fixes
- version-needed-to-extract was incorrect in central header, and version-made-by could be lower than that ([#100](https://github.com/zip-rs/zip2/pull/100))
- version-needed-to-extract was incorrect in central header, and version-made-by could be lower than that ([#100](https://github.com/zip-rs/zip2/pull/100))

### <!-- 7 -->⚙️ Miscellaneous Tasks
- Tweaks to make `version_needed` and `version_made_by` work with recently-merged changes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).