### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.1.1](https://github.com/zip-rs/zip2/compare/v2.1.0...v2.1.1) - 2024-05-28
+
+### <!-- 1 -->🐛 Bug Fixes
+- Derive `Debug` for `ZipWriter`
+- lower default version to 4.5 and use the version-needed-to-extract where feasible.
+
+### <!-- 2 -->🚜 Refactor
+- use a MIN_VERSION constant
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+- Bug fixes for debug implementation
+- Bug fixes for debug implementation
+- Update unit tests
+- Remove unused import
+
 ## [2.1.0](https://github.com/zip-rs/zip2/compare/v2.0.0...v2.1.0) - 2024-05-25
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "2.1.0"
+version = "2.1.1"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION
## 🤖 New release
* `zip`: 2.1.0 -> 2.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.1](https://github.com/zip-rs/zip2/compare/v2.1.0...v2.1.1) - 2024-05-28

### <!-- 1 -->🐛 Bug Fixes
- Derive `Debug` for `ZipWriter`
- lower default version to 4.5 and use the version-needed-to-extract where feasible.

### <!-- 2 -->🚜 Refactor
- use a MIN_VERSION constant

### <!-- 7 -->⚙️ Miscellaneous Tasks
- Bug fixes for debug implementation
- Bug fixes for debug implementation
- Update unit tests
- Remove unused import
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).