### PR TITLE
fix: Change `DateTime` to fully validate dates and discard inserted leap seconds

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -256,8 +256,9 @@ impl DateTime {
             && (1..=31).contains(&day)
             && hour <= 23
             && minute <= 59
-            && second <= 58
+            && second <= 60
         {
+            let second = second.min(58); // exFAT can't store leap seconds
             let max_day = match month {
                 1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
                 4 | 6 | 9 | 11 => 30,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1181,10 +1181,10 @@ mod test {
     fn datetime_bounds() {
         use super::DateTime;
 
-        assert!(DateTime::from_date_and_time(2000, 1, 1, 23, 59, 58).is_ok());
+        assert!(DateTime::from_date_and_time(2000, 1, 1, 23, 59, 60).is_ok());
         assert!(DateTime::from_date_and_time(2000, 1, 1, 24, 0, 0).is_err());
         assert!(DateTime::from_date_and_time(2000, 1, 1, 0, 60, 0).is_err());
-        assert!(DateTime::from_date_and_time(2000, 1, 1, 0, 0, 59).is_err());
+        assert!(DateTime::from_date_and_time(2000, 1, 1, 0, 0, 61).is_err());
 
         assert!(DateTime::from_date_and_time(2107, 12, 31, 0, 0, 0).is_ok());
         assert!(DateTime::from_date_and_time(1980, 1, 1, 0, 0, 0).is_ok());

--- a/src/types.rs
+++ b/src/types.rs
@@ -112,7 +112,7 @@ impl arbitrary::Arbitrary<'_> for DateTime {
             day: u.int_in_range(1..=31)?,
             hour: u.int_in_range(0..=23)?,
             minute: u.int_in_range(0..=59)?,
-            second: u.int_in_range(0..=60)?,
+            second: u.int_in_range(0..=58)?,
         })
     }
 }
@@ -238,7 +238,7 @@ impl DateTime {
     /// * day: [1, 31]
     /// * hour: [0, 23]
     /// * minute: [0, 59]
-    /// * second: [0, 60]
+    /// * second: [0, 58]
     pub fn from_date_and_time(
         year: u16,
         month: u8,
@@ -252,7 +252,7 @@ impl DateTime {
             && (1..=31).contains(&day)
             && hour <= 23
             && minute <= 59
-            && second <= 60
+            && second <= 58
         {
             Ok(DateTime {
                 year,
@@ -1093,8 +1093,8 @@ mod test {
     #[allow(clippy::unusual_byte_groupings)]
     fn datetime_max() {
         use super::DateTime;
-        let dt = DateTime::from_date_and_time(2107, 12, 31, 23, 59, 60).unwrap();
-        assert_eq!(dt.timepart(), 0b10111_111011_11110);
+        let dt = DateTime::from_date_and_time(2107, 12, 31, 23, 59, 58).unwrap();
+        assert_eq!(dt.timepart(), 0b10111_111011_11101);
         assert_eq!(dt.datepart(), 0b1111111_1100_11111);
     }
 
@@ -1156,9 +1156,9 @@ mod test {
         assert_eq!(
             format!(
                 "{}",
-                DateTime::from_date_and_time(2107, 12, 31, 23, 59, 59).unwrap()
+                DateTime::from_date_and_time(2107, 12, 31, 23, 59, 58).unwrap()
             ),
-            "2107-12-31 23:59:59"
+            "2107-12-31 23:59:58"
         );
     }
 
@@ -1166,10 +1166,10 @@ mod test {
     fn datetime_bounds() {
         use super::DateTime;
 
-        assert!(DateTime::from_date_and_time(2000, 1, 1, 23, 59, 60).is_ok());
+        assert!(DateTime::from_date_and_time(2000, 1, 1, 23, 59, 58).is_ok());
         assert!(DateTime::from_date_and_time(2000, 1, 1, 24, 0, 0).is_err());
         assert!(DateTime::from_date_and_time(2000, 1, 1, 0, 60, 0).is_err());
-        assert!(DateTime::from_date_and_time(2000, 1, 1, 0, 0, 61).is_err());
+        assert!(DateTime::from_date_and_time(2000, 1, 1, 0, 0, 59).is_err());
 
         assert!(DateTime::from_date_and_time(2107, 12, 31, 0, 0, 0).is_ok());
         assert!(DateTime::from_date_and_time(1980, 1, 1, 0, 0, 0).is_ok());


### PR DESCRIPTION
- Change `DateTime` to not accept after 58 seconds. This is because the valid range of values for the seconds of the MS-DOS date and time is 0 to 58.
- Change `DateTime` to not accept invalid days (e.g., 2018-06-31 or 2018-02-29). Accepts leap days like 2024-02-29.

I couldn't find the specification about the valid range of the date and time of the ZIP format. However, since exFAT also uses the MS-DOS date and time for the date and time, I think the valid range of values is the same as this.

[7.4.8.1 DoubleSeconds Field](https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#7481-doubleseconds-field):

> The DoubleSeconds field shall describe the seconds portion of the Timestamp field, in two-second multiples.
>
> The valid range of values for this field shall be:
>
> - 0, which represents 0 seconds
> - 29, which represents 58 seconds

[7.4.8.4 Day Field](https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#7484-day-field):

> The Day field shall describe the day portion of the Timestamp field.
>
> The valid range of values for this field shall be:
>
> - 1, which is the first day of the given month
> - The last day of the given month (the given month defines the number of valid days)
