### PR TITLE
fix dead code analysis warning

### DIFF
--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -220,6 +220,7 @@ mod test {
         }
     }
 
+    #[allow(dead_code)]
     #[derive(Default, Debug, Eq, PartialEq)]
     struct CounterVisitor(u64, u64);
     impl ZipStreamVisitor for CounterVisitor {


### PR DESCRIPTION
#79 is [failing CI](https://github.com/zip-rs/zip2/actions/runs/9702444803/job/26778309608?pr=79) due to a warning introduced in `src/read/stream.rs`:
```rust
 error: struct `CounterVisitor` is never constructed
Error:    --> src/read/stream.rs:224:12
    |
224 |     struct CounterVisitor(u64, u64);
    |            ^^^^^^^^^^^^^^
    |
    = note: `CounterVisitor` has a derived impl for the trait `Default`, but this is intentionally ignored during dead code analysis
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`
```

This appears to have been introduced by a newer nightly version updating behind our back and introducing this error, and not by any recent code change. I believe this should fix it.

We may be able to delete `CounterVisitor` entirely, but I'm not familiar with the testing in `stream.rs` so decided to avoid making bigger changes.