### PR TITLE
Multiple refactors

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,6 +1,6 @@
 //! Possible ZIP compression methods.
 
-use std::fmt;
+use std::{fmt, io};
 
 #[allow(deprecated)]
 /// Identifies the storage format used to compress a file within a ZIP archive.
@@ -188,6 +188,92 @@ pub const SUPPORTED_COMPRESSION_METHODS: &[CompressionMethod] = &[
     #[cfg(feature = "zstd")]
     CompressionMethod::Zstd,
 ];
+
+pub(crate) enum Decompressor<R: io::BufRead> {
+    Stored(R),
+    #[cfg(feature = "_deflate-any")]
+    Deflated(flate2::bufread::DeflateDecoder<R>),
+    #[cfg(feature = "deflate64")]
+    Deflate64(deflate64::Deflate64Decoder<R>),
+    #[cfg(feature = "bzip2")]
+    Bzip2(bzip2::bufread::BzDecoder<R>),
+    #[cfg(feature = "zstd")]
+    Zstd(zstd::Decoder<'static, R>),
+    #[cfg(feature = "lzma")]
+    Lzma(Box<crate::read::lzma::LzmaDecoder<R>>),
+    #[cfg(feature = "xz")]
+    Xz(crate::read::xz::XzDecoder<R>),
+}
+
+impl<R: io::BufRead> io::Read for Decompressor<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Decompressor::Stored(r) => r.read(buf),
+            #[cfg(feature = "_deflate-any")]
+            Decompressor::Deflated(r) => r.read(buf),
+            #[cfg(feature = "deflate64")]
+            Decompressor::Deflate64(r) => r.read(buf),
+            #[cfg(feature = "bzip2")]
+            Decompressor::Bzip2(r) => r.read(buf),
+            #[cfg(feature = "zstd")]
+            Decompressor::Zstd(r) => r.read(buf),
+            #[cfg(feature = "lzma")]
+            Decompressor::Lzma(r) => r.read(buf),
+            #[cfg(feature = "xz")]
+            Decompressor::Xz(r) => r.read(buf),
+        }
+    }
+}
+
+impl<R: io::BufRead> Decompressor<R> {
+    pub fn new(reader: R, compression_method: CompressionMethod) -> crate::result::ZipResult<Self> {
+        Ok(match compression_method {
+            CompressionMethod::Stored => Decompressor::Stored(reader),
+            #[cfg(feature = "_deflate-any")]
+            CompressionMethod::Deflated => {
+                Decompressor::Deflated(flate2::bufread::DeflateDecoder::new(reader))
+            }
+            #[cfg(feature = "deflate64")]
+            CompressionMethod::Deflate64 => {
+                Decompressor::Deflate64(deflate64::Deflate64Decoder::with_buffer(reader))
+            }
+            #[cfg(feature = "bzip2")]
+            CompressionMethod::Bzip2 => Decompressor::Bzip2(bzip2::bufread::BzDecoder::new(reader)),
+            #[cfg(feature = "zstd")]
+            CompressionMethod::Zstd => Decompressor::Zstd(zstd::Decoder::with_buffer(reader)?),
+            #[cfg(feature = "lzma")]
+            CompressionMethod::Lzma => {
+                Decompressor::Lzma(Box::new(crate::read::lzma::LzmaDecoder::new(reader)))
+            }
+            #[cfg(feature = "xz")]
+            CompressionMethod::Xz => Decompressor::Xz(crate::read::xz::XzDecoder::new(reader)),
+            _ => {
+                return Err(crate::result::ZipError::UnsupportedArchive(
+                    "Compression method not supported",
+                ))
+            }
+        })
+    }
+
+    /// Consumes this decoder, returning the underlying reader.
+    pub fn into_inner(self) -> R {
+        match self {
+            Decompressor::Stored(r) => r,
+            #[cfg(feature = "_deflate-any")]
+            Decompressor::Deflated(r) => r.into_inner(),
+            #[cfg(feature = "deflate64")]
+            Decompressor::Deflate64(r) => r.into_inner(),
+            #[cfg(feature = "bzip2")]
+            Decompressor::Bzip2(r) => r.into_inner(),
+            #[cfg(feature = "zstd")]
+            Decompressor::Zstd(r) => r.finish(),
+            #[cfg(feature = "lzma")]
+            Decompressor::Lzma(r) => r.into_inner(),
+            #[cfg(feature = "xz")]
+            Decompressor::Xz(r) => r.into_inner(),
+        }
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/src/read.rs
+++ b/src/read.rs
@@ -184,11 +184,11 @@ impl<'a> CryptoReader<'a> {
 }
 
 #[cold]
-fn invalid_state() -> io::Error {
-    io::Error::new(
+fn invalid_state<T>() -> io::Result<T> {
+    Err(io::Error::new(
         io::ErrorKind::Other,
         "ZipFileReader was in an invalid state",
-    )
+    ))
 }
 
 pub(crate) enum ZipFileReader<'a> {
@@ -200,7 +200,7 @@ pub(crate) enum ZipFileReader<'a> {
 impl<'a> Read for ZipFileReader<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
-            ZipFileReader::NoReader => Err(invalid_state()),
+            ZipFileReader::NoReader => invalid_state(),
             ZipFileReader::Raw(r) => r.read(buf),
             ZipFileReader::Compressed(r) => r.read(buf),
         }
@@ -208,7 +208,7 @@ impl<'a> Read for ZipFileReader<'a> {
 
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         match self {
-            ZipFileReader::NoReader => Err(invalid_state()),
+            ZipFileReader::NoReader => invalid_state(),
             ZipFileReader::Raw(r) => r.read_exact(buf),
             ZipFileReader::Compressed(r) => r.read_exact(buf),
         }
@@ -216,7 +216,7 @@ impl<'a> Read for ZipFileReader<'a> {
 
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         match self {
-            ZipFileReader::NoReader => Err(invalid_state()),
+            ZipFileReader::NoReader => invalid_state(),
             ZipFileReader::Raw(r) => r.read_to_end(buf),
             ZipFileReader::Compressed(r) => r.read_to_end(buf),
         }
@@ -224,7 +224,7 @@ impl<'a> Read for ZipFileReader<'a> {
 
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         match self {
-            ZipFileReader::NoReader => Err(invalid_state()),
+            ZipFileReader::NoReader => invalid_state(),
             ZipFileReader::Raw(r) => r.read_to_string(buf),
             ZipFileReader::Compressed(r) => r.read_to_string(buf),
         }
@@ -234,7 +234,7 @@ impl<'a> Read for ZipFileReader<'a> {
 impl<'a> ZipFileReader<'a> {
     fn into_inner(self) -> io::Result<io::Take<&'a mut dyn Read>> {
         match self {
-            ZipFileReader::NoReader => Err(invalid_state()),
+            ZipFileReader::NoReader => invalid_state(),
             ZipFileReader::Raw(r) => Ok(r),
             ZipFileReader::Compressed(r) => {
                 Ok(r.into_inner().into_inner().into_inner().into_inner())

--- a/src/read/lzma.rs
+++ b/src/read/lzma.rs
@@ -1,6 +1,6 @@
 use lzma_rs::decompress::{Options, Stream, UnpackedSize};
 use std::collections::VecDeque;
-use std::io::{copy, Error, Read, Result, Write};
+use std::io::{Read, Result, Write};
 
 const COMPRESSED_BYTES_TO_BUFFER: usize = 4096;
 
@@ -24,9 +24,8 @@ impl<R: Read> LzmaDecoder<R> {
         }
     }
 
-    pub fn finish(mut self) -> Result<VecDeque<u8>> {
-        copy(&mut self.compressed_reader, &mut self.stream)?;
-        self.stream.finish().map_err(Error::from)
+    pub fn into_inner(self) -> R {
+        self.compressed_reader
     }
 }
 

--- a/src/read/lzma.rs
+++ b/src/read/lzma.rs
@@ -1,8 +1,6 @@
 use lzma_rs::decompress::{Options, Stream, UnpackedSize};
 use std::collections::VecDeque;
-use std::io::{Read, Result, Write};
-
-const COMPRESSED_BYTES_TO_BUFFER: usize = 4096;
+use std::io::{BufRead, Read, Result, Write};
 
 const OPTIONS: Options = Options {
     unpacked_size: UnpackedSize::ReadFromHeader,
@@ -29,17 +27,15 @@ impl<R: Read> LzmaDecoder<R> {
     }
 }
 
-impl<R: Read> Read for LzmaDecoder<R> {
+impl<R: BufRead> Read for LzmaDecoder<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         let mut bytes_read = self.stream.get_output_mut().unwrap().read(buf)?;
         while bytes_read < buf.len() {
-            let mut next_compressed = [0u8; COMPRESSED_BYTES_TO_BUFFER];
-            let compressed_bytes_read = self.compressed_reader.read(&mut next_compressed)?;
-            if compressed_bytes_read == 0 {
+            let compressed_bytes = self.compressed_reader.fill_buf()?;
+            if compressed_bytes.is_empty() {
                 break;
             }
-            self.stream
-                .write_all(&next_compressed[..compressed_bytes_read])?;
+            self.stream.write_all(compressed_bytes)?;
             bytes_read += self
                 .stream
                 .get_output_mut()

--- a/src/write.rs
+++ b/src/write.rs
@@ -1297,7 +1297,7 @@ impl<W: Write + Seek> ZipWriter<W> {
         self.writing_to_file = true;
         self.writing_raw = true;
 
-        io::copy(file.get_raw_reader(), self)?;
+        io::copy(&mut file.take_raw_reader()?, self)?;
 
         Ok(())
     }


### PR DESCRIPTION
Multiples refactors to improve `read.rs`. 

- Split a `Decompressor` type (that we could even possibly make public)
- Remove dynamic state of `ZipFile` and its `crypto_reader` field
- Simplify `make_crypto_reader` parameters

Each commit can be reviewed separately.