### PR TITLE
refactor: Improve `FixedSizeBlock`

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -8,7 +8,7 @@ use crate::crc32::Crc32Reader;
 use crate::extra_fields::{ExtendedTimestamp, ExtraField};
 use crate::read::zip_archive::{Shared, SharedBuilder};
 use crate::result::{ZipError, ZipResult};
-use crate::spec::{self, FixedSizeBlock, Zip32CentralDirectoryEnd, ZIP64_ENTRY_THR};
+use crate::spec::{self, FixedSizeBlock, Pod, Zip32CentralDirectoryEnd, ZIP64_ENTRY_THR};
 use crate::types::{
     AesMode, AesVendorVersion, DateTime, System, ZipCentralEntryBlock, ZipFileData,
     ZipLocalEntryBlock,
@@ -1670,19 +1670,17 @@ pub fn read_zipfile_from_stream<'a, R: Read>(reader: &'a mut R) -> ZipResult<Opt
     // "magic" value (since the magic value will be from the central directory header if we've
     // finished iterating over all the actual files).
     /* TODO: smallvec? */
-    let mut block = [0u8; mem::size_of::<ZipLocalEntryBlock>()];
-    reader.read_exact(&mut block)?;
-    let block: Box<[u8]> = block.into();
 
-    let signature = spec::Magic::from_first_le_bytes(&block);
+    let mut block = ZipLocalEntryBlock::zeroed();
+    reader.read_exact(block.as_bytes_mut())?;
 
-    match signature {
+    match block.magic().from_le() {
         spec::Magic::LOCAL_FILE_HEADER_SIGNATURE => (),
         spec::Magic::CENTRAL_DIRECTORY_HEADER_SIGNATURE => return Ok(None),
         _ => return Err(ZipLocalEntryBlock::WRONG_MAGIC_ERROR),
     }
 
-    let block = ZipLocalEntryBlock::interpret(&block)?;
+    let block = block.from_le();
 
     let mut result = ZipFileData::from_local_block(block, reader)?;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, OnceLock};
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 
 use crate::result::{ZipError, ZipResult};
-use crate::spec::{self, FixedSizeBlock};
+use crate::spec::{self, FixedSizeBlock, Pod};
 
 pub(crate) mod ffi {
     pub const S_IFDIR: u32 = 0o0040000;
@@ -893,7 +893,7 @@ impl ZipFileData {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[repr(packed)]
+#[repr(packed, C)]
 pub(crate) struct ZipCentralEntryBlock {
     magic: spec::Magic,
     pub version_made_by: u16,
@@ -913,6 +913,8 @@ pub(crate) struct ZipCentralEntryBlock {
     pub external_file_attributes: u32,
     pub offset: u32,
 }
+
+unsafe impl Pod for ZipCentralEntryBlock {}
 
 impl FixedSizeBlock for ZipCentralEntryBlock {
     const MAGIC: spec::Magic = spec::Magic::CENTRAL_DIRECTORY_HEADER_SIGNATURE;
@@ -947,7 +949,7 @@ impl FixedSizeBlock for ZipCentralEntryBlock {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[repr(packed)]
+#[repr(packed, C)]
 pub(crate) struct ZipLocalEntryBlock {
     magic: spec::Magic,
     pub version_made_by: u16,
@@ -961,6 +963,8 @@ pub(crate) struct ZipLocalEntryBlock {
     pub file_name_length: u16,
     pub extra_field_length: u16,
 }
+
+unsafe impl Pod for ZipLocalEntryBlock {}
 
 impl FixedSizeBlock for ZipLocalEntryBlock {
     const MAGIC: spec::Magic = spec::Magic::LOCAL_FILE_HEADER_SIGNATURE;


### PR DESCRIPTION
- Remove allocations
- Make unsafe code easier to check
- Prevent potential `repr(Rust)` fields reordering
