### PR TITLE
refactor: Eliminate some magic numbers and unnecessary path prefixes

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -8,7 +8,7 @@ use crate::crc32::Crc32Reader;
 use crate::extra_fields::{ExtendedTimestamp, ExtraField};
 use crate::read::zip_archive::{Shared, SharedBuilder};
 use crate::result::{ZipError, ZipResult};
-use crate::spec::{self, FixedSizeBlock, Pod, Zip32CentralDirectoryEnd, ZIP64_ENTRY_THR};
+use crate::spec::{self, FixedSizeBlock, Pod, Zip32CDEBlock, Zip32CentralDirectoryEnd, ZIP64_ENTRY_THR};
 use crate::types::{
     AesMode, AesVendorVersion, DateTime, System, ZipCentralEntryBlock, ZipFileData,
     ZipLocalEntryBlock,
@@ -618,7 +618,7 @@ impl<R: Read + Seek> ZipArchive<R> {
         // comment length. Therefore:
         /* TODO: compute this from constant sizes and offsets! */
         reader.seek(io::SeekFrom::End(
-            -(20 + 22 + footer.zip_file_comment.len() as i64),
+            -(20 + size_of::<Zip32CDEBlock> as i64 + footer.zip_file_comment.len() as i64),
         ))?;
         let locator64 = spec::Zip64CentralDirectoryEndLocator::parse(reader)?;
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -1938,19 +1938,17 @@ fn update_local_zip64_extra_field<T: Write + Seek>(
     writer: &mut T,
     file: &ZipFileData,
 ) -> ZipResult<()> {
-    if !file.large_file {
-        return Err(ZipError::InvalidArchive(
+    let block = file.zip64_extra_field_block().ok_or(
+        ZipError::InvalidArchive(
             "Attempted to update a nonexistent ZIP64 extra field",
-        ));
-    }
+        )
+    )?;
 
-    let zip64_extra_field = file.header_start
+    let zip64_extra_field_start = file.header_start
         + mem::size_of::<ZipLocalEntryBlock>() as u64
         + file.file_name_raw.len() as u64;
 
-    writer.seek(SeekFrom::Start(zip64_extra_field))?;
-
-    let block = file.zip64_extra_field_block().unwrap();
+    writer.seek(SeekFrom::Start(zip64_extra_field_start))?;
     let block = block.serialize();
     writer.write_all(&block)?;
     Ok(())

--- a/src/write.rs
+++ b/src/write.rs
@@ -50,7 +50,7 @@ use zstd::stream::write::Encoder as ZstdEncoder;
 enum MaybeEncrypted<W> {
     Unencrypted(W),
     #[cfg(feature = "aes-crypto")]
-    Aes(crate::aes::AesWriter<W>),
+    Aes(AesWriter<W>),
     ZipCrypto(crate::zipcrypto::ZipCryptoWriter<W>),
 }
 
@@ -649,7 +649,7 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     /// read previously-written files and not overwrite them.
     ///
     /// Note: when using an `inner` that cannot overwrite flushed bytes, do not wrap it in a
-    /// [std::io::BufWriter], because that has a [Seek::seek] method that implicitly calls
+    /// [BufWriter], because that has a [Seek::seek] method that implicitly calls
     /// [BufWriter::flush], and ZipWriter needs to seek backward to update each file's header with
     /// the size and checksum after writing the body.
     ///
@@ -859,7 +859,7 @@ impl<W: Write + Seek> ZipWriter<W> {
                 "No file has been started",
             )));
         }
-        self.stats.hasher = crc32fast::Hasher::new_with_initial_len(crc32, length);
+        self.stats.hasher = Hasher::new_with_initial_len(crc32, length);
         self.stats.bytes_written = length;
         Ok(())
     }
@@ -1005,11 +1005,11 @@ impl<W: Write + Seek> ZipWriter<W> {
                 #[cfg(feature = "aes-crypto")]
                 Some(EncryptWith::Aes { mode, password }) => {
                     let aeswriter = AesWriter::new(
-                        mem::replace(&mut self.inner, GenericZipWriter::Closed).unwrap(),
+                        mem::replace(&mut self.inner, Closed).unwrap(),
                         mode,
                         password.as_bytes(),
                     )?;
-                    self.inner = GenericZipWriter::Storer(MaybeEncrypted::Aes(aeswriter));
+                    self.inner = Storer(MaybeEncrypted::Aes(aeswriter));
                 }
                 Some(EncryptWith::ZipCrypto(keys, ..)) => {
                     let mut zipwriter = crate::zipcrypto::ZipCryptoWriter {
@@ -1220,7 +1220,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     ///```
     pub fn merge_archive<R>(&mut self, mut source: ZipArchive<R>) -> ZipResult<()>
     where
-        R: Read + io::Seek,
+        R: Read + Seek,
     {
         self.finish_file()?;
 
@@ -1615,7 +1615,7 @@ impl<W: Write + Seek> GenericZipWriter<W> {
             match compression {
                 Stored => {
                     if compression_level.is_some() {
-                        Err(ZipError::UnsupportedArchive(
+                        Err(UnsupportedArchive(
                             "Unsupported compression level",
                         ))
                     } else {
@@ -1637,7 +1637,7 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                         compression_level.unwrap_or(default),
                         deflate_compression_level_range(),
                     )
-                    .ok_or(ZipError::UnsupportedArchive(
+                    .ok_or(UnsupportedArchive(
                         "Unsupported compression level",
                     ))? as u32;
 
@@ -1681,7 +1681,7 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                     }
                 }
                 #[cfg(feature = "deflate64")]
-                CompressionMethod::Deflate64 => Err(ZipError::UnsupportedArchive(
+                CompressionMethod::Deflate64 => Err(UnsupportedArchive(
                     "Compressing Deflate64 is not supported",
                 )),
                 #[cfg(feature = "bzip2")]
@@ -1690,7 +1690,7 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                         compression_level.unwrap_or(bzip2::Compression::default().level() as i64),
                         bzip2_compression_level_range(),
                     )
-                    .ok_or(ZipError::UnsupportedArchive(
+                    .ok_or(UnsupportedArchive(
                         "Unsupported compression level",
                     ))? as u32;
                     Ok(Box::new(move |bare| {
@@ -1700,7 +1700,7 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                         ))
                     }))
                 }
-                CompressionMethod::AES => Err(ZipError::UnsupportedArchive(
+                CompressionMethod::AES => Err(UnsupportedArchive(
                     "AES encryption is enabled through FileOptions::with_aes_encryption",
                 )),
                 #[cfg(feature = "zstd")]
@@ -1709,7 +1709,7 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                         compression_level.unwrap_or(zstd::DEFAULT_COMPRESSION_LEVEL as i64),
                         zstd::compression_level_range(),
                     )
-                    .ok_or(ZipError::UnsupportedArchive(
+                    .ok_or(UnsupportedArchive(
                         "Unsupported compression level",
                     ))?;
                     Ok(Box::new(move |bare| {
@@ -1725,7 +1725,7 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                     Err(UnsupportedArchive("XZ isn't supported for compression"))
                 }
                 CompressionMethod::Unsupported(..) => {
-                    Err(ZipError::UnsupportedArchive("Unsupported compression"))
+                    Err(UnsupportedArchive("Unsupported compression"))
                 }
             }
         }
@@ -1832,7 +1832,7 @@ fn clamp_opt<T: Ord + Copy, U: Ord + Copy + TryFrom<T>>(
     }
 }
 
-fn update_aes_extra_data<W: Write + io::Seek>(
+fn update_aes_extra_data<W: Write + Seek>(
     writer: &mut W,
     file: &mut ZipFileData,
 ) -> ZipResult<()> {
@@ -1842,7 +1842,7 @@ fn update_aes_extra_data<W: Write + io::Seek>(
 
     let extra_data_start = file.extra_data_start.unwrap();
 
-    writer.seek(io::SeekFrom::Start(
+    writer.seek(SeekFrom::Start(
         extra_data_start + file.aes_extra_data_start,
     ))?;
 
@@ -1925,7 +1925,7 @@ fn write_local_zip64_extra_field<T: Write>(writer: &mut T, file: &ZipFileData) -
     // This entry in the Local header MUST include BOTH original
     // and compressed file size fields.
     let Some(block) = file.zip64_extra_field_block() else {
-        return Err(ZipError::InvalidArchive(
+        return Err(InvalidArchive(
             "Attempted to write a ZIP64 extra field for a file that's within zip32 limits",
         ));
     };
@@ -1938,14 +1938,14 @@ fn update_local_zip64_extra_field<T: Write + Seek>(
     writer: &mut T,
     file: &ZipFileData,
 ) -> ZipResult<()> {
-    let block = file.zip64_extra_field_block().ok_or(
-        ZipError::InvalidArchive(
+    let block = file
+        .zip64_extra_field_block()
+        .ok_or(InvalidArchive(
             "Attempted to update a nonexistent ZIP64 extra field",
-        )
-    )?;
+        ))?;
 
     let zip64_extra_field_start = file.header_start
-        + mem::size_of::<ZipLocalEntryBlock>() as u64
+        + size_of::<ZipLocalEntryBlock>() as u64
         + file.file_name_raw.len() as u64;
 
     writer.seek(SeekFrom::Start(zip64_extra_field_start))?;
@@ -1992,14 +1992,13 @@ mod test {
     use crate::zipcrypto::ZipCryptoKeys;
     use crate::CompressionMethod::Stored;
     use crate::ZipArchive;
-    use std::io;
     use std::io::{Cursor, Read, Write};
     use std::marker::PhantomData;
     use std::path::PathBuf;
 
     #[test]
     fn write_empty_zip() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer.set_comment("ZIP");
         let result = writer.finish().unwrap();
         assert_eq!(result.get_ref().len(), 25);
@@ -2018,7 +2017,7 @@ mod test {
 
     #[test]
     fn write_zip_dir() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .add_directory(
                 "test",
@@ -2046,7 +2045,7 @@ mod test {
 
     #[test]
     fn write_symlink_simple() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .add_symlink(
                 "name",
@@ -2081,7 +2080,7 @@ mod test {
         path.push("..");
         path.push(".");
         path.push("example.txt");
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .start_file_from_path(path, SimpleFileOptions::default())
             .unwrap();
@@ -2091,7 +2090,7 @@ mod test {
 
     #[test]
     fn write_symlink_wonky_paths() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .add_symlink(
                 "directory\\link",
@@ -2123,9 +2122,9 @@ mod test {
 
     #[test]
     fn write_mimetype_zip() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         let options = FileOptions {
-            compression_method: CompressionMethod::Stored,
+            compression_method: Stored,
             compression_level: None,
             last_modified_time: DateTime::default(),
             permissions: Some(33188),
@@ -2160,9 +2159,9 @@ mod test {
 
     #[test]
     fn write_non_utf8() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         let options = FileOptions {
-            compression_method: CompressionMethod::Stored,
+            compression_method: Stored,
             compression_level: None,
             last_modified_time: DateTime::default(),
             permissions: Some(33188),
@@ -2197,7 +2196,7 @@ mod test {
 
     #[test]
     fn path_to_string() {
-        let mut path = std::path::PathBuf::new();
+        let mut path = PathBuf::new();
         #[cfg(windows)]
         path.push(r"C:\");
         #[cfg(unix)]
@@ -2212,7 +2211,7 @@ mod test {
 
     #[test]
     fn test_shallow_copy() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         let options = FileOptions {
             compression_method: CompressionMethod::default(),
             compression_level: None,
@@ -2262,7 +2261,7 @@ mod test {
 
     #[test]
     fn test_deep_copy() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         let options = FileOptions {
             compression_method: CompressionMethod::default(),
             compression_level: None,
@@ -2310,7 +2309,7 @@ mod test {
 
     #[test]
     fn duplicate_filenames() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .start_file("foo/bar/test", SimpleFileOptions::default())
             .unwrap();
@@ -2324,7 +2323,7 @@ mod test {
 
     #[test]
     fn test_filename_looks_like_zip64_locator() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .start_file(
                 "PK\u{6}\u{7}\0\0\0\u{11}\0\0\0\0\0\0\0\0\0\0\0\0",
@@ -2337,7 +2336,7 @@ mod test {
 
     #[test]
     fn test_filename_looks_like_zip64_locator_2() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .start_file(
                 "PK\u{6}\u{6}\0\0\0\0\0\0\0\0\0\0PK\u{6}\u{7}\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
@@ -2350,7 +2349,7 @@ mod test {
 
     #[test]
     fn test_filename_looks_like_zip64_locator_2a() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .start_file(
                 "PK\u{6}\u{6}PK\u{6}\u{7}\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
@@ -2363,7 +2362,7 @@ mod test {
 
     #[test]
     fn test_filename_looks_like_zip64_locator_3() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .start_file("\0PK\u{6}\u{6}", SimpleFileOptions::default())
             .unwrap();
@@ -2379,7 +2378,7 @@ mod test {
 
     #[test]
     fn test_filename_looks_like_zip64_locator_4() {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .start_file("PK\u{6}\u{6}", SimpleFileOptions::default())
             .unwrap();
@@ -2405,7 +2404,7 @@ mod test {
 
     #[test]
     fn test_filename_looks_like_zip64_locator_5() -> ZipResult<()> {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .add_directory("", SimpleFileOptions::default().with_alignment(21))
             .unwrap();
@@ -2431,7 +2430,7 @@ mod test {
 
     #[test]
     fn remove_shallow_copy_keeps_original() -> ZipResult<()> {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer
             .start_file("original", SimpleFileOptions::default())
             .unwrap();
@@ -2450,7 +2449,7 @@ mod test {
 
     #[test]
     fn remove_encrypted_file() -> ZipResult<()> {
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         let first_file_options = SimpleFileOptions::default()
             .with_alignment(65535)
             .with_deprecated_encryption(b"Password");
@@ -2467,7 +2466,7 @@ mod test {
         let mut options = SimpleFileOptions::default();
         options = options.with_deprecated_encryption(b"Password");
         options.alignment = 65535;
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer.add_symlink("", "s\t\0\0ggggg\0\0", options).unwrap();
         writer.abort_file().unwrap();
         let zip = writer.finish().unwrap();
@@ -2483,7 +2482,7 @@ mod test {
         options = options
             .compression_method(CompressionMethod::default())
             .compression_level(Some(264));
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer.start_file("", options).unwrap();
         writer.write_all(&[]).unwrap();
         writer.write_all(&[]).unwrap();
@@ -2493,11 +2492,11 @@ mod test {
     #[test]
     fn crash_with_no_features() -> ZipResult<()> {
         const ORIGINAL_FILE_NAME: &str = "PK\u{6}\u{6}\0\0\0\0\0\0\0\0\0\u{2}g\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\u{1}\0\0\0\0\0\0\0\0\0\0PK\u{6}\u{7}\0\0\0\0\0\0\0\0\0\0\0\0\u{7}\0\t'";
-        let mut writer = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         let mut options = SimpleFileOptions::default();
         options = options
             .with_alignment(3584)
-            .compression_method(CompressionMethod::Stored);
+            .compression_method(Stored);
         writer.start_file(ORIGINAL_FILE_NAME, options)?;
         let archive = writer.finish()?;
         let mut writer = ZipWriter::new_append(archive)?;
@@ -2510,9 +2509,9 @@ mod test {
     fn test_alignment() {
         let page_size = 4096;
         let options = SimpleFileOptions::default()
-            .compression_method(CompressionMethod::Stored)
+            .compression_method(Stored)
             .with_alignment(page_size);
-        let mut zip = ZipWriter::new(io::Cursor::new(Vec::new()));
+        let mut zip = ZipWriter::new(Cursor::new(Vec::new()));
         let contents = b"sleeping";
         let () = zip.start_file("sleep", options).unwrap();
         let _count = zip.write(&contents[..]).unwrap();

--- a/src/write.rs
+++ b/src/write.rs
@@ -1769,7 +1769,7 @@ impl<W: Write + Seek> GenericZipWriter<W> {
     }
 
     const fn is_closed(&self) -> bool {
-        matches!(*self, GenericZipWriter::Closed)
+        matches!(*self, Closed)
     }
 
     fn get_plain(&mut self) -> &mut W {


### PR DESCRIPTION
<!-- 
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Please make sure your PR's target repo is `zip-rs/zip2` and not `zip-rs/zip-old`. The latter
  repo is no longer maintained, and I will archive it after closing the pre-existing issues.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start 
  with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
  This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged.

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->
