### PR TITLE
feat: Expose `ZipArchive::central_directory_start`

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -1030,6 +1030,11 @@ impl<R: Read + Seek> ZipArchive<R> {
         self.shared.files.len()
     }
 
+    /// Get the starting offset of the zip central directory.
+    pub fn central_directory_start(&self) -> u64 {
+        self.shared.dir_start
+    }
+
     /// Whether this zip archive contains no files
     pub fn is_empty(&self) -> bool {
         self.len() == 0


### PR DESCRIPTION
Introduces `ZipArchive::central_directory_start` to get the starting offset of the central directory (similar to `ZipFile::central_header_start`).

Closes #209