### PR TITLE
New read api

### DIFF
--- a/src/aes.rs
+++ b/src/aes.rs
@@ -66,7 +66,7 @@ pub struct AesReader<R> {
     data_length: u64,
 }
 
-impl<R: Read> AesReader<R> {
+impl<R> AesReader<R> {
     pub const fn new(reader: R, aes_mode: AesMode, compressed_size: u64) -> AesReader<R> {
         let data_length = compressed_size
             - (PWD_VERIFY_LENGTH + AUTH_CODE_LENGTH + aes_mode.salt_length()) as u64;
@@ -77,7 +77,9 @@ impl<R: Read> AesReader<R> {
             data_length,
         }
     }
+}
 
+impl<R: Read> AesReader<R> {
     /// Read the AES header bytes and validate the password.
     ///
     /// Even if the validation succeeds, there is still a 1 in 65536 chance that an incorrect
@@ -150,7 +152,7 @@ impl<R: Read> AesReader<R> {
 /// There is a 1 in 65536 chance that an invalid password passes that check.
 /// After the data has been read and decrypted an HMAC will be checked and provide a final means
 /// to check if either the password is invalid or if the data has been changed.
-pub struct AesReaderValid<R: Read> {
+pub struct AesReaderValid<R> {
     reader: R,
     data_remaining: u64,
     cipher: Cipher,
@@ -214,7 +216,7 @@ impl<R: Read> Read for AesReaderValid<R> {
     }
 }
 
-impl<R: Read> AesReaderValid<R> {
+impl<R> AesReaderValid<R> {
     /// Consumes this decoder, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.reader

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -83,6 +83,110 @@ impl<R: Read> Read for Crc32Reader<R> {
     }
 }
 
+pub(crate) mod non_crypto {
+    use std::io;
+    use std::io::prelude::*;
+
+    use crc32fast::Hasher;
+
+    /// Reader that validates the CRC32 when it reaches the EOF.
+    pub struct Crc32Reader<R> {
+        inner: R,
+        hasher: Hasher,
+        check: u32,
+    }
+
+    impl<R> Crc32Reader<R> {
+        /// Get a new Crc32Reader which checks the inner reader against checksum.
+        pub(crate) fn new(inner: R, checksum: u32) -> Self {
+            Crc32Reader {
+                inner,
+                hasher: Hasher::new(),
+                check: checksum,
+            }
+        }
+
+        fn check_matches(&self) -> Result<(), &'static str> {
+            let res = self.hasher.clone().finalize();
+            if self.check == res {
+                Ok(())
+            } else {
+                /* TODO: make this into our own Crc32Error error type! */
+                Err("Invalid checksum")
+            }
+        }
+    }
+
+    impl<R: Read> Read for Crc32Reader<R> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            /* We want to make sure we only check the hash when the input stream is exhausted. */
+            if buf.is_empty() {
+                /* If the input buf is empty (this shouldn't happen, but isn't guaranteed), we
+                 * still want to "pull" from the source in case it surfaces an i/o error. This will
+                 * always return a count of Ok(0) if successful. */
+                return self.inner.read(buf);
+            }
+
+            let count = self.inner.read(buf)?;
+            if count == 0 {
+                return self
+                    .check_matches()
+                    .map(|()| 0)
+                    /* TODO: use io::Error::other for MSRV >=1.74 */
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
+            }
+            self.hasher.update(&buf[..count]);
+            Ok(count)
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn test_empty_reader() {
+            let data: &[u8] = b"";
+            let mut buf = [0; 1];
+
+            let mut reader = Crc32Reader::new(data, 0);
+            assert_eq!(reader.read(&mut buf).unwrap(), 0);
+
+            let mut reader = Crc32Reader::new(data, 1);
+            assert!(reader
+                .read(&mut buf)
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid checksum"));
+        }
+
+        #[test]
+        fn test_byte_by_byte() {
+            let data: &[u8] = b"1234";
+            let mut buf = [0; 1];
+
+            let mut reader = Crc32Reader::new(data, 0x9be3e0a3);
+            assert_eq!(reader.read(&mut buf).unwrap(), 1);
+            assert_eq!(reader.read(&mut buf).unwrap(), 1);
+            assert_eq!(reader.read(&mut buf).unwrap(), 1);
+            assert_eq!(reader.read(&mut buf).unwrap(), 1);
+            assert_eq!(reader.read(&mut buf).unwrap(), 0);
+            // Can keep reading 0 bytes after the end
+            assert_eq!(reader.read(&mut buf).unwrap(), 0);
+        }
+
+        #[test]
+        fn test_zero_read() {
+            let data: &[u8] = b"1234";
+            let mut buf = [0; 5];
+
+            let mut reader = Crc32Reader::new(data, 0x9be3e0a3);
+            assert_eq!(reader.read(&mut buf[..0]).unwrap(), 0);
+            assert_eq!(reader.read(&mut buf).unwrap(), 4);
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,8 @@
 #![warn(missing_docs)]
 #![allow(unexpected_cfgs)] // Needed for cfg(fuzzing) on nightly as of 2024-05-06
 pub use crate::compression::{CompressionMethod, SUPPORTED_COMPRESSION_METHODS};
-pub use crate::read::HasZipMetadata;
 pub use crate::read::ZipArchive;
+pub use crate::read::{EntryData, HasZipMetadata};
 pub use crate::spec::{ZIP64_BYTES_THR, ZIP64_ENTRY_THR};
 pub use crate::types::{AesMode, DateTime};
 pub use crate::write::ZipWriter;

--- a/src/read.rs
+++ b/src/read.rs
@@ -13,7 +13,7 @@ use crate::spec::{
     Zip64CentralDirectoryEnd, ZIP64_ENTRY_THR,
 };
 use crate::types::{
-    AesMode, AesVendorVersion, DateTime, System, ZipCentralEntryBlock, ZipFileData,
+    AesMode, AesModeInfo, AesVendorVersion, DateTime, System, ZipCentralEntryBlock, ZipFileData,
     ZipLocalEntryBlock,
 };
 use crate::zipcrypto::{ZipCryptoReader, ZipCryptoReaderValid, ZipCryptoValidator};
@@ -24,7 +24,6 @@ use std::fs::create_dir_all;
 use std::io::{self, copy, prelude::*, sink, SeekFrom};
 use std::mem;
 use std::mem::size_of;
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
@@ -91,6 +90,7 @@ pub(crate) mod zip_archive {
     ///
     /// ```no_run
     /// use std::io::prelude::*;
+    /// use zip::read::ArchiveEntry;
     /// fn list_zip_contents(reader: impl Read + Seek) -> zip::result::ZipResult<()> {
     ///     use zip::HasZipMetadata;
     ///     let mut zip = zip::ZipArchive::new(reader)?;
@@ -116,9 +116,16 @@ pub(crate) mod zip_archive {
 use crate::aes::PWD_VERIFY_LENGTH;
 use crate::extra_fields::UnicodeExtraField;
 use crate::result::ZipError::{InvalidArchive, InvalidPassword};
-use crate::spec::is_dir;
 use crate::types::ffi::S_IFLNK;
 use crate::unstable::{path_to_string, LittleEndianReadExt};
+
+use crate::crc32::non_crypto::Crc32Reader as NewCrc32Reader;
+use crate::unstable::read::{
+    construct_decompressing_reader, find_entry_content_range, CryptoEntryReader,
+    CryptoKeyValidationSource,
+};
+pub use crate::unstable::read::{ArchiveEntry, ZipEntry};
+
 pub use zip_archive::ZipArchive;
 
 #[allow(clippy::large_enum_variant)]
@@ -343,9 +350,9 @@ fn find_content_seek<'a, R: Read + Seek>(
     Ok(SeekableTake::new(reader, data.compressed_size)?)
 }
 
-fn find_data_start(
+pub(crate) fn find_data_start(
     data: &ZipFileData,
-    reader: &mut (impl Read + Seek + Sized),
+    reader: &mut (impl Read + Seek),
 ) -> Result<u64, ZipError> {
     // Go to start of data.
     reader.seek(SeekFrom::Start(data.header_start))?;
@@ -377,7 +384,7 @@ pub(crate) fn make_crypto_reader<'a>(
     data: &ZipFileData,
     reader: io::Take<&'a mut dyn Read>,
     password: Option<&[u8]>,
-    aes_info: Option<(AesMode, AesVendorVersion, CompressionMethod)>,
+    aes_info: Option<AesModeInfo>,
 ) -> ZipResult<CryptoReader<'a>> {
     #[allow(deprecated)]
     {
@@ -394,7 +401,14 @@ pub(crate) fn make_crypto_reader<'a>(
             ))
         }
         #[cfg(feature = "aes-crypto")]
-        (Some(password), Some((aes_mode, vendor_version, _))) => CryptoReader::Aes {
+        (
+            Some(password),
+            Some(AesModeInfo {
+                aes_mode,
+                vendor_version,
+                ..
+            }),
+        ) => CryptoReader::Aes {
             reader: AesReader::new(reader, aes_mode, data.compressed_size).validate(password)?,
             vendor_version,
         },
@@ -479,6 +493,69 @@ impl<R> ZipArchive<R> {
         }
         Some(total)
     }
+
+    const fn order_lower_upper_bounds(a: u64, b: u64) -> (u64, u64) {
+        if a > b {
+            (b, a)
+        } else {
+            (a, b)
+        }
+    }
+
+    /// Number of files contained in this zip.
+    pub fn len(&self) -> usize {
+        self.shared.files.len()
+    }
+
+    /// Whether this zip archive contains no files
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get the offset from the beginning of the underlying reader that this zip begins at, in bytes.
+    ///
+    /// Normally this value is zero, but if the zip has arbitrary data prepended to it, then this value will be the size
+    /// of that prepended data.
+    pub fn offset(&self) -> u64 {
+        self.shared.offset
+    }
+
+    /// Get the comment of the zip archive.
+    pub fn comment(&self) -> &[u8] {
+        &self.comment
+    }
+
+    /// Returns an iterator over all the file and directory names in this archive.
+    pub fn file_names(&self) -> impl Iterator<Item = &str> {
+        self.shared.files.keys().map(|s| s.as_ref())
+    }
+
+    /// Get the index of a file entry by name, if it's present.
+    #[inline(always)]
+    pub fn index_for_name(&self, name: &str) -> Option<usize> {
+        self.shared.files.get_index_of(name)
+    }
+
+    /// Get the index of a file entry by path, if it's present.
+    #[inline(always)]
+    pub fn index_for_path<T: AsRef<Path>>(&self, path: T) -> Option<usize> {
+        self.index_for_name(&path_to_string(path))
+    }
+
+    #[inline(always)]
+    fn index_for_name_err(&self, name: impl AsRef<str>) -> Result<usize, ZipError> {
+        self.index_for_name(name.as_ref())
+            .ok_or(ZipError::FileNotFound)
+    }
+
+    /// Get the name of a file entry, if it's present.
+    #[inline(always)]
+    pub fn name_for_index(&self, index: usize) -> Option<&str> {
+        self.shared
+            .files
+            .get_index(index)
+            .map(|(name, _)| name.as_ref())
+    }
 }
 
 impl<R: Read + Seek> ZipArchive<R> {
@@ -538,10 +615,8 @@ impl<R: Read + Seek> ZipArchive<R> {
         self.reader.rewind()?;
         /* Find the end of the file data. */
         let length_to_read = self.shared.dir_start;
-        /* Produce a Read that reads bytes up until the start of the central directory header.
-         * This "as &mut dyn Read" trick is used elsewhere to avoid having to clone the underlying
-         * handle, which it really shouldn't need to anyway. */
-        let mut limited_raw = (&mut self.reader as &mut dyn Read).take(length_to_read);
+        /* Produce a Read that reads bytes up until the start of the central directory header. */
+        let mut limited_raw = self.reader.by_ref().take(length_to_read);
         /* Copy over file data from source archive directly. */
         io::copy(&mut limited_raw, &mut w)?;
 
@@ -598,14 +673,6 @@ impl<R: Read + Seek> ZipArchive<R> {
             cde_position: cde_start_pos,
             is_zip64: false,
         })
-    }
-
-    const fn order_lower_upper_bounds(a: u64, b: u64) -> (u64, u64) {
-        if a > b {
-            (b, a)
-        } else {
-            (a, b)
-        }
     }
 
     fn get_directory_info_zip64(
@@ -866,27 +933,8 @@ impl<R: Read + Seek> ZipArchive<R> {
         &mut self,
         file_number: usize,
     ) -> ZipResult<Option<AesInfo>> {
-        let (_, data) = self
-            .shared
-            .files
-            .get_index(file_number)
-            .ok_or(ZipError::FileNotFound)?;
-
-        let limit_reader = find_content(data, &mut self.reader)?;
-        match data.aes_mode {
-            None => Ok(None),
-            Some((aes_mode, _, _)) => {
-                let (verification_value, salt) =
-                    AesReader::new(limit_reader, aes_mode, data.compressed_size)
-                        .get_verification_value_and_salt()?;
-                let aes_info = AesInfo {
-                    aes_mode,
-                    verification_value,
-                    salt,
-                };
-                Ok(Some(aes_info))
-            }
-        }
+        let entry = self.by_index_raw_generic(file_number)?;
+        entry.get_aes_verification_key_and_salt()
     }
 
     /// Read a ZIP archive, collecting the files it contains.
@@ -929,7 +977,7 @@ impl<R: Read + Seek> ZipArchive<R> {
         #[cfg(unix)]
         let mut files_by_unix_mode = Vec::new();
         for i in 0..self.len() {
-            let mut file = self.by_index(i)?;
+            let mut file = self.by_index_generic(i)?;
             let filepath = file
                 .enclosed_name()
                 .ok_or(InvalidArchive("Invalid file path"))?;
@@ -965,7 +1013,7 @@ impl<R: Read + Seek> ZipArchive<R> {
                     };
                     let target = target.into_boxed_str();
                     let target_is_dir_from_archive =
-                        self.shared.files.contains_key(&target) && is_dir(&target);
+                        self.shared.files.contains_key(&target) && spec::is_dir(&target);
                     let target_path = directory.as_ref().join(OsString::from(target.to_string()));
                     let target_is_dir = if target_is_dir_from_archive {
                         true
@@ -982,7 +1030,7 @@ impl<R: Read + Seek> ZipArchive<R> {
                 }
                 continue;
             }
-            let mut file = self.by_index(i)?;
+            let mut file = self.by_index_generic(i)?;
             let mut outfile = fs::File::create(&outpath)?;
             io::copy(&mut file, &mut outfile)?;
             #[cfg(unix)]
@@ -1025,34 +1073,6 @@ impl<R: Read + Seek> ZipArchive<R> {
         Ok(())
     }
 
-    /// Number of files contained in this zip.
-    pub fn len(&self) -> usize {
-        self.shared.files.len()
-    }
-
-    /// Whether this zip archive contains no files
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Get the offset from the beginning of the underlying reader that this zip begins at, in bytes.
-    ///
-    /// Normally this value is zero, but if the zip has arbitrary data prepended to it, then this value will be the size
-    /// of that prepended data.
-    pub fn offset(&self) -> u64 {
-        self.shared.offset
-    }
-
-    /// Get the comment of the zip archive.
-    pub fn comment(&self) -> &[u8] {
-        &self.comment
-    }
-
-    /// Returns an iterator over all the file and directory names in this archive.
-    pub fn file_names(&self) -> impl Iterator<Item = &str> {
-        self.shared.files.keys().map(|s| s.as_ref())
-    }
-
     /// Search for a file entry by name, decrypt with given password
     ///
     /// # Warning
@@ -1073,27 +1093,6 @@ impl<R: Read + Seek> ZipArchive<R> {
     /// Search for a file entry by name
     pub fn by_name(&mut self, name: &str) -> ZipResult<ZipFile> {
         self.by_name_with_optional_password(name, None)
-    }
-
-    /// Get the index of a file entry by name, if it's present.
-    #[inline(always)]
-    pub fn index_for_name(&self, name: &str) -> Option<usize> {
-        self.shared.files.get_index_of(name)
-    }
-
-    /// Get the index of a file entry by path, if it's present.
-    #[inline(always)]
-    pub fn index_for_path<T: AsRef<Path>>(&self, path: T) -> Option<usize> {
-        self.index_for_name(&path_to_string(path))
-    }
-
-    /// Get the name of a file entry, if it's present.
-    #[inline(always)]
-    pub fn name_for_index(&self, index: usize) -> Option<&str> {
-        self.shared
-            .files
-            .get_index(index)
-            .map(|(name, _)| name.as_ref())
     }
 
     /// Search for a file entry by name and return a seekable object.
@@ -1131,9 +1130,7 @@ impl<R: Read + Seek> ZipArchive<R> {
         name: &str,
         password: Option<&[u8]>,
     ) -> ZipResult<ZipFile<'a>> {
-        let Some(index) = self.shared.files.get_index_of(name) else {
-            return Err(ZipError::FileNotFound);
-        };
+        let index = self.index_for_name_err(name)?;
         self.by_index_with_optional_password(index, password)
     }
 
@@ -1211,6 +1208,149 @@ impl<R: Read + Seek> ZipArchive<R> {
     }
 }
 
+impl<R> ZipArchive<R>
+where
+    R: Read + Seek,
+{
+    /// Search for a file entry by name
+    pub fn by_name_generic(
+        &mut self,
+        name: impl AsRef<str>,
+    ) -> ZipResult<ZipEntry<'_, impl Read + '_>> {
+        let index = self.index_for_name_err(name)?;
+        self.by_index_generic(index)
+    }
+
+    /// Get a contained file by index
+    pub fn by_index_generic(
+        &mut self,
+        file_number: usize,
+    ) -> ZipResult<ZipEntry<'_, impl Read + '_>> {
+        let Self {
+            ref mut reader,
+            ref shared,
+            ..
+        } = self;
+        let (_, data) = shared
+            .files
+            .get_index(file_number)
+            .ok_or(ZipError::FileNotFound)?;
+        let content = find_entry_content_range(data, reader)?;
+        let entry_reader = construct_decompressing_reader(&data.compression_method, content)?;
+        let crc32_reader = NewCrc32Reader::new(entry_reader, data.crc32);
+        Ok(ZipEntry {
+            data,
+            reader: crc32_reader,
+        })
+    }
+
+    /// Get a contained file by name without decompressing it
+    pub fn by_name_raw_generic(
+        &mut self,
+        name: impl AsRef<str>,
+    ) -> ZipResult<ZipEntry<'_, impl Read + '_>> {
+        let index = self.index_for_name_err(name)?;
+        self.by_index_raw_generic(index)
+    }
+
+    /// Get a contained file by index without decompressing it
+    pub fn by_index_raw_generic(
+        &mut self,
+        file_number: usize,
+    ) -> ZipResult<ZipEntry<'_, impl Read + '_>> {
+        let Self {
+            ref mut reader,
+            ref shared,
+            ..
+        } = self;
+        let (_, data) = shared
+            .files
+            .get_index(file_number)
+            .ok_or(ZipError::FileNotFound)?;
+        let content = find_entry_content_range(data, reader)?;
+        Ok(ZipEntry {
+            data,
+            reader: content,
+        })
+    }
+
+    /// Search for a file entry by name, decrypt with given password
+    ///
+    /// # Warning
+    ///
+    /// The implementation of the cryptographic algorithms has not
+    /// gone through a correctness review, and you should assume it is insecure:
+    /// passwords used with this API may be compromised.
+    ///
+    /// This function sometimes accepts wrong password. This is because the ZIP spec only allows us
+    /// to check for a 1/256 chance that the password is correct.
+    /// There are many passwords out there that will also pass the validity checks
+    /// we are able to perform. This is a weakness of the ZipCrypto algorithm,
+    /// due to its fairly primitive approach to cryptography.
+    pub fn by_name_decrypt_generic(
+        &mut self,
+        name: impl AsRef<str>,
+        password: &[u8],
+    ) -> ZipResult<ZipEntry<'_, impl Read + '_>> {
+        let index = self.index_for_name_err(name)?;
+        self.by_index_decrypt_generic(index, password)
+    }
+
+    /// Get a contained file by index, decrypt with given password
+    ///
+    /// # Warning
+    ///
+    /// The implementation of the cryptographic algorithms has not
+    /// gone through a correctness review, and you should assume it is insecure:
+    /// passwords used with this API may be compromised.
+    ///
+    /// This function sometimes accepts wrong password. This is because the ZIP spec only allows us
+    /// to check for a 1/256 chance that the password is correct.
+    /// There are many passwords out there that will also pass the validity checks
+    /// we are able to perform. This is a weakness of the ZipCrypto algorithm,
+    /// due to its fairly primitive approach to cryptography.
+    pub fn by_index_decrypt_generic(
+        &mut self,
+        file_number: usize,
+        password: &[u8],
+    ) -> ZipResult<ZipEntry<'_, impl Read + '_>> {
+        let Self {
+            ref mut reader,
+            ref shared,
+            ..
+        } = self;
+        let (_, data) = shared
+            .files
+            .get_index(file_number)
+            .ok_or(ZipError::FileNotFound)?;
+
+        let content = find_entry_content_range(data, reader)?;
+
+        let final_reader = if data.encrypted {
+            let crypto_variant = CryptoKeyValidationSource::from_data(data)?;
+            let is_ae2_encrypted = crypto_variant.is_ae2_encrypted();
+            let crypto_reader = crypto_variant.make_crypto_reader(password, content)?;
+            let entry_reader =
+                construct_decompressing_reader(&data.compression_method, crypto_reader)?;
+            if is_ae2_encrypted {
+                /* Ae2 voids crc checking: https://www.winzip.com/en/support/aes-encryption/ */
+                CryptoEntryReader::Ae2Encrypted(entry_reader)
+            } else {
+                CryptoEntryReader::NonAe2Encrypted(NewCrc32Reader::new(entry_reader, data.crc32))
+            }
+        } else {
+            /* Not encrypted, so do the same as in .by_index_generic(): */
+            let entry_reader = construct_decompressing_reader(&data.compression_method, content)?;
+            CryptoEntryReader::Unencrypted(NewCrc32Reader::new(entry_reader, data.crc32))
+        };
+
+        Ok(ZipEntry {
+            data,
+            reader: final_reader,
+        })
+    }
+}
+
 /// Holds the AES information of a file in the zip archive
 #[derive(Debug)]
 #[cfg(feature = "aes-crypto")]
@@ -1257,7 +1397,7 @@ fn read_variable_length_byte_field<R: Read>(reader: &mut R, len: usize) -> io::R
 }
 
 /// Parse a central directory entry to collect the information for the file.
-fn central_header_to_zip_file_inner<R: Read>(
+pub(crate) fn central_header_to_zip_file_inner<R: Read>(
     reader: &mut R,
     archive_offset: u64,
     central_header_start: u64,
@@ -1329,13 +1469,8 @@ fn central_header_to_zip_file_inner<R: Read>(
         aes_extra_data_start: 0,
         extra_fields: Vec::new(),
     };
-    match parse_extra_field(&mut result) {
-        Ok(stripped_extra_field) => {
-            result.extra_field = stripped_extra_field;
-        }
-        Err(ZipError::Io(..)) => {}
-        Err(e) => return Err(e),
-    }
+    let stripped_extra_field = parse_extra_field(&mut result)?;
+    result.extra_field = stripped_extra_field;
 
     let aes_enabled = result.compression_method == CompressionMethod::AES;
     if aes_enabled && result.aes_mode.is_none() {
@@ -1364,9 +1499,17 @@ pub(crate) fn parse_extra_field(file: &mut ZipFileData) -> ZipResult<Option<Arc<
 
     /* TODO: codify this structure into Zip64ExtraFieldBlock fields! */
     let mut position = reader.position() as usize;
-    while (position) < len {
+    while position < len {
         let old_position = position;
-        let remove = parse_single_extra_field(file, &mut reader, position as u64, false)?;
+        let remove = match parse_single_extra_field(file, &mut reader, position as u64, false) {
+            Ok(b) => b,
+            /* If we get an error reading too far, then assume this is an extra field we don't know
+             * how to handle, and just return the remaining amount. */
+            Err(ZipError::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                return Ok(Some(processed_extra_field))
+            }
+            Err(e) => return Err(e),
+        };
         position = reader.position() as usize;
         if remove {
             let remaining = len - (position - old_position);
@@ -1440,12 +1583,17 @@ pub(crate) fn parse_single_extra_field<R: Read>(
                 0x0002 => AesVendorVersion::Ae2,
                 _ => return Err(InvalidArchive("Invalid AES vendor version")),
             };
-            match aes_mode {
-                0x01 => file.aes_mode = Some((AesMode::Aes128, vendor_version, compression_method)),
-                0x02 => file.aes_mode = Some((AesMode::Aes192, vendor_version, compression_method)),
-                0x03 => file.aes_mode = Some((AesMode::Aes256, vendor_version, compression_method)),
-                _ => return Err(InvalidArchive("Invalid AES encryption strength")),
+            let aes_mode = match aes_mode {
+                0x01 => AesMode::Aes128,
+                0x02 => AesMode::Aes192,
+                0x03 => AesMode::Aes256,
+                _ => return Err(ZipError::InvalidArchive("Invalid AES encryption strength")),
             };
+            file.aes_mode = Some(AesModeInfo {
+                aes_mode,
+                vendor_version,
+                compression_method,
+            });
             file.compression_method = compression_method;
             file.aes_extra_data_start = bytes_already_read;
         }
@@ -1597,9 +1745,10 @@ impl<'a> ZipFile<'a> {
     pub fn last_modified(&self) -> Option<DateTime> {
         self.data.last_modified_time
     }
+
     /// Returns whether the file is actually a directory
     pub fn is_dir(&self) -> bool {
-        is_dir(self.name())
+        self.data.is_dir()
     }
 
     /// Returns whether the file is actually a symbolic link
@@ -1627,8 +1776,8 @@ impl<'a> ZipFile<'a> {
     pub fn extra_data(&self) -> Option<&[u8]> {
         self.get_metadata()
             .extra_field
-            .as_ref()
-            .map(|v| v.deref().deref())
+            .as_deref()
+            .map(|v| v.as_ref())
     }
 
     /// Get the starting offset of the data of the compressed file

--- a/src/read/xz.rs
+++ b/src/read/xz.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 #[derive(Debug)]
-pub struct XzDecoder<R: BufRead> {
+pub struct XzDecoder<R> {
     compressed_reader: R,
     stream_size: usize,
     buf: VecDeque<u8>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -420,6 +420,13 @@ impl TryFrom<DateTime> for OffsetDateTime {
 pub const MIN_VERSION: u8 = 10;
 pub const DEFAULT_VERSION: u8 = 45;
 
+#[derive(Debug, Copy, Clone)]
+pub struct AesModeInfo {
+    pub aes_mode: AesMode,
+    pub vendor_version: AesVendorVersion,
+    pub compression_method: CompressionMethod,
+}
+
 /// Structure representing a ZIP file.
 #[derive(Debug, Clone, Default)]
 pub struct ZipFileData {
@@ -470,7 +477,7 @@ pub struct ZipFileData {
     /// Reserve local ZIP64 extra field
     pub large_file: bool,
     /// AES mode if applicable
-    pub aes_mode: Option<(AesMode, AesVendorVersion, CompressionMethod)>,
+    pub aes_mode: Option<AesModeInfo>,
     /// Specifies where in the extra data the AES metadata starts
     pub aes_extra_data_start: u64,
 
@@ -621,7 +628,7 @@ impl ZipFileData {
         extra_data_start: Option<u64>,
         aes_extra_data_start: u64,
         compression_method: crate::compression::CompressionMethod,
-        aes_mode: Option<(AesMode, AesVendorVersion, CompressionMethod)>,
+        aes_mode: Option<AesModeInfo>,
         extra_field: &[u8],
     ) -> Self
     where

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -5,6 +5,8 @@ use std::io;
 use std::io::{Read, Write};
 use std::path::{Component, Path, MAIN_SEPARATOR};
 
+pub mod read;
+
 /// Provides high level API for reading from a stream.
 pub mod stream {
     pub use crate::read::stream::*;

--- a/src/unstable/read.rs
+++ b/src/unstable/read.rs
@@ -1,0 +1,752 @@
+//! Alternate implementation of [`crate::read`].
+
+use crate::compression::CompressionMethod;
+use crate::crc32::non_crypto::Crc32Reader;
+use crate::extra_fields::ExtraField;
+use crate::read::find_data_start;
+use crate::result::{ZipError, ZipResult};
+use crate::types::ffi::S_IFLNK;
+use crate::types::{DateTime, ZipFileData};
+use crate::zipcrypto::{ZipCryptoReader, ZipCryptoReaderValid, ZipCryptoValidator};
+
+#[cfg(feature = "lzma")]
+use crate::read::lzma::LzmaDecoder;
+#[cfg(feature = "xz")]
+use crate::read::xz::XzDecoder;
+#[cfg(feature = "aes-crypto")]
+use crate::{
+    aes::{AesReader, AesReaderValid},
+    read::AesInfo,
+    types::{AesModeInfo, AesVendorVersion},
+};
+
+#[cfg(feature = "bzip2")]
+use bzip2::read::BzDecoder;
+#[cfg(feature = "deflate64")]
+use deflate64::Deflate64Decoder;
+#[cfg(feature = "deflate-flate2")]
+use flate2::read::DeflateDecoder;
+#[cfg(feature = "zstd")]
+use zstd::stream::read::Decoder as ZstdDecoder;
+
+use std::io::{self, Read, Seek};
+use std::path::PathBuf;
+use std::slice;
+
+pub(crate) enum EntryReader<R> {
+    Stored(R),
+    #[cfg(feature = "_deflate-any")]
+    Deflated(DeflateDecoder<R>),
+    #[cfg(feature = "deflate64")]
+    Deflate64(Deflate64Decoder<io::BufReader<R>>),
+    #[cfg(feature = "bzip2")]
+    Bzip2(BzDecoder<R>),
+    #[cfg(feature = "zstd")]
+    Zstd(ZstdDecoder<'static, io::BufReader<R>>),
+    #[cfg(feature = "lzma")]
+    /* According to clippy, this is >30x larger than the other variants, so we box it to avoid
+     * unnecessary large stack allocations. */
+    Lzma(Box<LzmaDecoder<io::BufReader<R>>>),
+    #[cfg(feature = "xz")]
+    Xz(XzDecoder<io::BufReader<R>>),
+}
+
+impl<R> Read for EntryReader<R>
+where
+    R: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Stored(r) => r.read(buf),
+            #[cfg(feature = "_deflate-any")]
+            Self::Deflated(r) => r.read(buf),
+            #[cfg(feature = "deflate64")]
+            Self::Deflate64(r) => r.read(buf),
+            #[cfg(feature = "bzip2")]
+            Self::Bzip2(r) => r.read(buf),
+            #[cfg(feature = "zstd")]
+            Self::Zstd(r) => r.read(buf),
+            #[cfg(feature = "lzma")]
+            Self::Lzma(r) => r.read(buf),
+            #[cfg(feature = "xz")]
+            Self::Xz(r) => r.read(buf),
+        }
+    }
+}
+
+/// A struct for reading a zip file
+pub struct ZipEntry<'a, R> {
+    pub(crate) data: &'a ZipFileData,
+    pub(crate) reader: R,
+}
+
+impl<'a, R> Read for ZipEntry<'a, R>
+where
+    R: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.reader.read(buf)
+    }
+}
+
+impl<'a, R> ZipEntry<'a, R>
+where
+    R: Read,
+{
+    /// Returns the verification value and salt for the AES encryption of the file
+    ///
+    /// # Returns
+    ///
+    /// - None if the file is not encrypted with AES
+    #[cfg(feature = "aes-crypto")]
+    pub fn get_aes_verification_key_and_salt(self) -> ZipResult<Option<AesInfo>> {
+        let Self { data, reader } = self;
+        if let Some(AesModeInfo { aes_mode, .. }) = data.aes_mode {
+            let (verification_value, salt) = AesReader::new(reader, aes_mode, data.compressed_size)
+                .get_verification_value_and_salt()?;
+            let aes_info = AesInfo {
+                aes_mode,
+                verification_value,
+                salt,
+            };
+            Ok(Some(aes_info))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+mod sealed_data {
+    use super::ZipFileData;
+
+    #[doc(hidden)]
+    pub trait ArchiveData {
+        fn data(&self) -> &ZipFileData;
+    }
+}
+
+pub trait ArchiveEntry: Read + sealed_data::ArchiveData {
+    /// Get the version of the file
+    fn version_made_by(&self) -> (u8, u8) {
+        (
+            self.data().version_made_by / 10,
+            self.data().version_made_by % 10,
+        )
+    }
+
+    /// Get the name of the file
+    ///
+    /// # Warnings
+    ///
+    /// It is dangerous to use this name directly when extracting an archive.
+    /// It may contain an absolute path (`/etc/shadow`), or break out of the
+    /// current directory (`../runtime`). Carelessly writing to these paths
+    /// allows an attacker to craft a ZIP archive that will overwrite critical
+    /// files.
+    ///
+    /// You can use the [`ZipFile::enclosed_name`] method to validate the name
+    /// as a safe path.
+    fn name(&self) -> &str {
+        &self.data().file_name
+    }
+
+    /// Get the name of the file, in the raw (internal) byte representation.
+    ///
+    /// The encoding of this data is currently undefined.
+    fn name_raw(&self) -> &[u8] {
+        &self.data().file_name_raw
+    }
+
+    /// Rewrite the path, ignoring any path components with special meaning.
+    ///
+    /// - Absolute paths are made relative
+    /// - [`ParentDir`]s are ignored
+    /// - Truncates the filename at a NULL byte
+    ///
+    /// This is appropriate if you need to be able to extract *something* from
+    /// any archive, but will easily misrepresent trivial paths like
+    /// `foo/../bar` as `foo/bar` (instead of `bar`). Because of this,
+    /// [`ZipFile::enclosed_name`] is the better option in most scenarios.
+    ///
+    /// [`ParentDir`]: `Component::ParentDir`
+    fn mangled_name(&self) -> PathBuf {
+        self.data().file_name_sanitized()
+    }
+
+    /// Ensure the file path is safe to use as a [`Path`].
+    ///
+    /// - It can't contain NULL bytes
+    /// - It can't resolve to a path outside the current directory
+    ///   > `foo/../bar` is fine, `foo/../../bar` is not.
+    /// - It can't be an absolute path
+    ///
+    /// This will read well-formed ZIP files correctly, and is resistant
+    /// to path-based exploits. It is recommended over
+    /// [`ZipFile::mangled_name`].
+    fn enclosed_name(&self) -> Option<PathBuf> {
+        self.data().enclosed_name()
+    }
+
+    /// Get the comment of the file
+    fn comment(&self) -> &str {
+        &self.data().file_comment
+    }
+
+    /// Get the compression method used to store the file
+    fn compression(&self) -> CompressionMethod {
+        self.data().compression_method
+    }
+
+    /// Get the size of the file, in bytes, in the archive
+    fn compressed_size(&self) -> u64 {
+        self.data().compressed_size
+    }
+
+    /// Get the size of the file, in bytes, when uncompressed
+    fn size(&self) -> u64 {
+        self.data().uncompressed_size
+    }
+
+    /// Get the time the file was last modified
+    fn last_modified(&self) -> Option<DateTime> {
+        self.data().last_modified_time
+    }
+
+    /// Returns whether the file is actually a directory
+    fn is_dir(&self) -> bool {
+        self.data().is_dir()
+    }
+
+    /// Returns whether the file is actually a symbolic link
+    fn is_symlink(&self) -> bool {
+        self.unix_mode()
+            .is_some_and(|mode| mode & S_IFLNK == S_IFLNK)
+    }
+
+    /// Returns whether the file is a normal file (i.e. not a directory or symlink)
+    fn is_file(&self) -> bool {
+        !self.is_dir() && !self.is_symlink()
+    }
+
+    /// Get unix mode for the file
+    fn unix_mode(&self) -> Option<u32> {
+        self.data().unix_mode()
+    }
+
+    /// Get the CRC32 hash of the original file
+    fn crc32(&self) -> u32 {
+        self.data().crc32
+    }
+
+    /// Get the extra data of the zip header for this file
+    fn extra_data(&self) -> Option<&[u8]> {
+        self.data().extra_field.as_deref().map(|v| v.as_ref())
+    }
+
+    /// Get the starting offset of the data of the compressed file
+    fn data_start(&self) -> u64 {
+        *self.data().data_start.get().unwrap()
+    }
+
+    /// Get the starting offset of the zip header for this file
+    fn header_start(&self) -> u64 {
+        self.data().header_start
+    }
+    /// Get the starting offset of the zip header in the central directory for this file
+    fn central_header_start(&self) -> u64 {
+        self.data().central_header_start
+    }
+
+    /// iterate through all extra fields
+    fn extra_data_fields(&self) -> slice::Iter<'_, ExtraField> {
+        self.data().extra_fields.iter()
+    }
+}
+
+impl<'a, R> sealed_data::ArchiveData for ZipEntry<'a, R> {
+    fn data(&self) -> &ZipFileData {
+        self.data
+    }
+}
+
+impl<'a, R> ArchiveEntry for ZipEntry<'a, R> where R: Read {}
+
+pub(crate) fn find_entry_content_range<R>(
+    data: &ZipFileData,
+    mut reader: R,
+) -> Result<io::Take<R>, ZipError>
+where
+    R: Read + Seek,
+{
+    // TODO: use .get_or_try_init() once stabilized to provide a closure returning a Result!
+    let data_start = match data.data_start.get() {
+        Some(data_start) => *data_start,
+        None => find_data_start(data, &mut reader)?,
+    };
+
+    reader.seek(io::SeekFrom::Start(data_start))?;
+    Ok(reader.take(data.compressed_size))
+}
+
+pub(crate) fn construct_decompressing_reader<R>(
+    compression_method: &CompressionMethod,
+    reader: R,
+) -> Result<EntryReader<R>, ZipError>
+where
+    /* TODO: this really shouldn't be required upon construction (especially since the reader
+     * doesn't need to be mutable, indicating the Read capability isn't used), but multiple of our
+     * constituent constructors require it. We should be able to make upstream PRs to fix these. */
+    R: Read,
+{
+    match compression_method {
+        &CompressionMethod::Stored => Ok(EntryReader::Stored(reader)),
+        #[cfg(feature = "_deflate-any")]
+        &CompressionMethod::Deflated => {
+            let deflate_reader = DeflateDecoder::new(reader);
+            Ok(EntryReader::Deflated(deflate_reader))
+        }
+        #[cfg(feature = "deflate64")]
+        &CompressionMethod::Deflate64 => {
+            let deflate64_reader = Deflate64Decoder::new(reader);
+            Ok(EntryReader::Deflate64(deflate64_reader))
+        }
+        #[cfg(feature = "bzip2")]
+        &CompressionMethod::Bzip2 => {
+            let bzip2_reader = BzDecoder::new(reader);
+            Ok(EntryReader::Bzip2(bzip2_reader))
+        }
+        #[cfg(feature = "zstd")]
+        &CompressionMethod::Zstd => {
+            let zstd_reader = ZstdDecoder::new(reader).unwrap();
+            Ok(EntryReader::Zstd(zstd_reader))
+        }
+        #[cfg(feature = "lzma")]
+        &CompressionMethod::Lzma => {
+            let buf_reader = io::BufReader::new(reader);
+            let lzma_reader = LzmaDecoder::new(buf_reader);
+            Ok(EntryReader::Lzma(Box::new(lzma_reader)))
+        }
+        #[cfg(feature = "xz")]
+        &CompressionMethod::Xz => {
+            let buf_reader = io::BufReader::new(reader);
+            let xz_reader = XzDecoder::new(buf_reader);
+            Ok(EntryReader::Xz(xz_reader))
+        }
+        /* TODO: make this into its own EntryReadError error type! */
+        _ => Err(ZipError::UnsupportedArchive(
+            "Compression method not supported",
+        )),
+    }
+}
+
+pub(crate) enum CryptoReader<R> {
+    ZipCrypto(ZipCryptoReaderValid<R>),
+    #[cfg(feature = "aes-crypto")]
+    Aes(AesReaderValid<R>),
+}
+
+impl<R> Read for CryptoReader<R>
+where
+    R: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            CryptoReader::ZipCrypto(r) => r.read(buf),
+            #[cfg(feature = "aes-crypto")]
+            CryptoReader::Aes(r) => r.read(buf),
+        }
+    }
+}
+
+pub(crate) enum CryptoKeyValidationSource {
+    Crc32(u32),
+    DateTime(DateTime),
+    #[cfg(feature = "aes-crypto")]
+    Aes {
+        info: AesModeInfo,
+        compressed_size: u64,
+    },
+}
+
+impl CryptoKeyValidationSource {
+    pub fn from_data(data: &ZipFileData) -> Result<Self, ZipError> {
+        debug_assert!(
+            data.encrypted,
+            "should never enter this method except on encrypted entries"
+        );
+
+        #[allow(deprecated)]
+        if let CompressionMethod::Unsupported(_) = data.compression_method {
+            /* TODO: make this into its own EntryReadError error type! */
+            return Err(ZipError::UnsupportedArchive(
+                "Compression method not supported",
+            ));
+        }
+
+        #[allow(unused_variables)]
+        if let Some(info) = data.aes_mode {
+            #[cfg(feature = "aes-crypto")]
+            return Ok(Self::Aes {
+                info,
+                compressed_size: data.compressed_size,
+            });
+            /* TODO: make this into its own EntryReadError error type! */
+            #[cfg(not(feature = "aes-crypto"))]
+            return Err(ZipError::UnsupportedArchive(
+                "AES encrypted files cannot be decrypted without the aes-crypto feature.",
+            ));
+        }
+
+        if let Some(last_modified_time) = data.last_modified_time {
+            /* TODO: use let chains once stabilized! */
+            if data.using_data_descriptor {
+                return Ok(Self::DateTime(last_modified_time));
+            }
+        }
+
+        Ok(Self::Crc32(data.crc32))
+    }
+
+    /// Returns `true` if the data is encrypted using AE2.
+    pub const fn is_ae2_encrypted(&self) -> bool {
+        match self {
+            #[cfg(feature = "aes-crypto")]
+            Self::Aes {
+                info:
+                    AesModeInfo {
+                        vendor_version: AesVendorVersion::Ae2,
+                        ..
+                    },
+                ..
+            } => true,
+            _ => false,
+        }
+    }
+
+    pub fn make_crypto_reader<R>(
+        self,
+        password: &[u8],
+        reader: R,
+    ) -> Result<CryptoReader<R>, ZipError>
+    where
+        R: Read,
+    {
+        match self {
+            #[cfg(feature = "aes-crypto")]
+            Self::Aes {
+                info: AesModeInfo { aes_mode, .. },
+                compressed_size,
+            } => {
+                let aes_reader =
+                    AesReader::new(reader, aes_mode, compressed_size).validate(password)?;
+                Ok(CryptoReader::Aes(aes_reader))
+            }
+            Self::DateTime(last_modified_time) => {
+                let validator = ZipCryptoValidator::InfoZipMsdosTime(last_modified_time.timepart());
+                let zc_reader = ZipCryptoReader::new(reader, password).validate(validator)?;
+                Ok(CryptoReader::ZipCrypto(zc_reader))
+            }
+            Self::Crc32(crc32) => {
+                let validator = ZipCryptoValidator::PkzipCrc32(crc32);
+                let zc_reader = ZipCryptoReader::new(reader, password).validate(validator)?;
+                Ok(CryptoReader::ZipCrypto(zc_reader))
+            }
+        }
+    }
+}
+
+pub(crate) enum CryptoEntryReader<R> {
+    Unencrypted(Crc32Reader<EntryReader<R>>),
+    Ae2Encrypted(EntryReader<CryptoReader<R>>),
+    NonAe2Encrypted(Crc32Reader<EntryReader<CryptoReader<R>>>),
+}
+
+impl<R> Read for CryptoEntryReader<R>
+where
+    R: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Unencrypted(r) => r.read(buf),
+            Self::Ae2Encrypted(r) => r.read(buf),
+            Self::NonAe2Encrypted(r) => r.read(buf),
+        }
+    }
+}
+
+pub mod streaming {
+    use super::{
+        construct_decompressing_reader, sealed_data, ArchiveEntry, Crc32Reader, ZipError,
+        ZipFileData, ZipResult,
+    };
+
+    use crate::read::{central_header_to_zip_file_inner, parse_extra_field};
+    use crate::spec::{self, FixedSizeBlock};
+    use crate::types::{ZipCentralEntryBlock, ZipLocalEntryBlock};
+
+    use std::io::{self, Read};
+    use std::mem;
+    use std::ops;
+
+    pub struct StreamingArchive<R> {
+        reader: R,
+        remaining_before_next_entry: u64,
+        first_metadata_block: Option<[u8; mem::size_of::<ZipLocalEntryBlock>()]>,
+    }
+
+    impl<R> StreamingArchive<R> {
+        pub const fn new(reader: R) -> Self {
+            Self {
+                reader,
+                remaining_before_next_entry: 0,
+                first_metadata_block: None,
+            }
+        }
+
+        pub fn into_inner(self) -> R {
+            let Self { reader, .. } = self;
+            reader
+        }
+    }
+
+    impl<R> StreamingArchive<R>
+    where
+        R: Read,
+    {
+        fn drain_remaining(&mut self) -> Result<(), ZipError> {
+            let Self {
+                ref mut reader,
+                ref mut remaining_before_next_entry,
+                ..
+            } = self;
+            if *remaining_before_next_entry > 0 {
+                io::copy(
+                    &mut reader.by_ref().take(*remaining_before_next_entry),
+                    &mut io::sink(),
+                )?;
+                *remaining_before_next_entry = 0;
+            }
+            Ok(())
+        }
+
+        pub fn next_entry(&mut self) -> ZipResult<Option<StreamingZipEntry<impl Read + '_>>> {
+            // We can't use the typical ::parse() method, as we follow separate code paths depending
+            // on the "magic" value (since the magic value will be from the central directory header
+            // if we've finished iterating over all the actual files).
+            self.drain_remaining()?;
+            let Self {
+                ref mut reader,
+                ref mut remaining_before_next_entry,
+                ref mut first_metadata_block,
+            } = self;
+            assert_eq!(0, *remaining_before_next_entry);
+
+            let mut block = [0u8; mem::size_of::<ZipLocalEntryBlock>()];
+            reader.read_exact(&mut block)?;
+
+            let signature = spec::Magic::from_first_le_bytes(block.as_ref());
+            match signature {
+                ZipLocalEntryBlock::MAGIC => (),
+                /* If the signature corresponds to the first central directory entry, then we are
+                 * out of file entries. We can't seek backwards in a stream, so we save the block
+                 * we just read to our mutable state. */
+                ZipCentralEntryBlock::MAGIC => {
+                    assert!(
+                        first_metadata_block.is_none(),
+                        "metadata block should never be set except exactly once"
+                    );
+                    assert!(
+                        mem::size_of::<ZipLocalEntryBlock>()
+                            < mem::size_of::<ZipCentralEntryBlock>()
+                    );
+                    *first_metadata_block = Some(block);
+                    return Ok(None);
+                }
+                _ => return Err(ZipLocalEntryBlock::WRONG_MAGIC_ERROR),
+            }
+            let block = ZipLocalEntryBlock::interpret(&block)?;
+
+            let mut data = ZipFileData::from_local_block(block, reader)?;
+
+            let stripped_extra_field = parse_extra_field(&mut data)?;
+            data.extra_field = stripped_extra_field;
+
+            let limit_reader =
+                DrainWrapper::new(data.compressed_size, remaining_before_next_entry, reader);
+            let entry_reader =
+                construct_decompressing_reader(&data.compression_method, limit_reader)?;
+            let crc32_reader = Crc32Reader::new(entry_reader, data.crc32);
+            Ok(Some(StreamingZipEntry {
+                data,
+                reader: crc32_reader,
+            }))
+        }
+
+        pub fn next_metadata_entry(&mut self) -> ZipResult<Option<ZipStreamFileMetadata>> {
+            /* We should only need to drain remaining exactly once (if at all), since that's only
+             * employed if the end user fails to read the entire contents of a streaming file
+             * entry. */
+            self.drain_remaining()?;
+            let Self {
+                ref mut reader,
+                ref remaining_before_next_entry,
+                ref mut first_metadata_block,
+            } = self;
+            assert_eq!(0, *remaining_before_next_entry);
+
+            /* Get the bytes out of the stream necessary to create a parseable central block. */
+            let block: [u8; mem::size_of::<ZipCentralEntryBlock>()] =
+                match first_metadata_block.take() {
+                    /* If we have a block we tried to parse earlier from .next_entry(), get the
+                     * data from there, then read the additional bytes necessary to construct
+                     * a central directory entry. This should always happen exactly once. */
+                    Some(block) => {
+                        assert!(
+                            mem::size_of::<ZipLocalEntryBlock>()
+                                < mem::size_of::<ZipCentralEntryBlock>()
+                        );
+                        assert_eq!(block.len(), mem::size_of::<ZipLocalEntryBlock>());
+
+                        let mut remaining_block = [0u8; mem::size_of::<ZipCentralEntryBlock>()
+                            - mem::size_of::<ZipLocalEntryBlock>()];
+                        reader.read_exact(remaining_block.as_mut())?;
+
+                        let mut joined_block = [0u8; mem::size_of::<ZipCentralEntryBlock>()];
+                        joined_block[..block.len()].copy_from_slice(&block);
+                        joined_block[block.len()..].copy_from_slice(&remaining_block);
+                        joined_block
+                    }
+                    /* After the first central block is parsed, we should always go into this
+                     * branch, reading the necessary bytes from the stream. */
+                    None => {
+                        let mut block = [0u8; mem::size_of::<ZipCentralEntryBlock>()];
+                        match reader.read_exact(&mut block) {
+                            Ok(()) => (),
+                            /* The reader is done! This is expected to happen exactly once when the
+                             * stream is completely finished. */
+                            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+                            Err(e) => return Err(e.into()),
+                        };
+                        block
+                    }
+                };
+            // Parse central header
+            let block = ZipCentralEntryBlock::interpret(&block)?;
+
+            // Give archive_offset and central_header_start dummy value 0, since
+            // they are not used in the output.
+            let archive_offset = 0;
+            let central_header_start = 0;
+
+            let data = central_header_to_zip_file_inner(
+                reader,
+                archive_offset,
+                central_header_start,
+                block,
+            )?;
+            Ok(Some(ZipStreamFileMetadata(data)))
+        }
+    }
+
+    struct DrainWrapper<'a, R> {
+        full_extent: usize,
+        current_progress: usize,
+        remaining_to_notify: &'a mut u64,
+        inner: R,
+    }
+
+    impl<'a, R> DrainWrapper<'a, R> {
+        pub fn new(extent: u64, remaining_to_notify: &'a mut u64, inner: R) -> Self {
+            Self {
+                full_extent: extent.try_into().unwrap(),
+                current_progress: 0,
+                remaining_to_notify,
+                inner,
+            }
+        }
+
+        fn remaining(&self) -> usize {
+            debug_assert!(self.current_progress <= self.full_extent);
+            self.full_extent - self.current_progress
+        }
+    }
+
+    impl<'a, R> Read for DrainWrapper<'a, R>
+    where
+        R: Read,
+    {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            assert!(!buf.is_empty());
+            let to_read = self.remaining().min(buf.len());
+            /* If the input is exhausted, or `buf` was empty, we are done. */
+            if to_read == 0 {
+                return Ok(0);
+            }
+
+            let count = self.inner.read(&mut buf[..to_read])?;
+            if count == 0 {
+                /* `to_read` was >0, so this was unexpected: */
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "failed to read expected number of bytes for zip entry from stream",
+                ));
+            }
+
+            debug_assert!(count <= to_read);
+            self.current_progress += count;
+            Ok(count)
+        }
+    }
+
+    impl<'a, R> ops::Drop for DrainWrapper<'a, R> {
+        fn drop(&mut self) {
+            assert_eq!(
+                0, *self.remaining_to_notify,
+                "remaining should always be zero before drop is called"
+            );
+            *self.remaining_to_notify = self.remaining().try_into().unwrap();
+        }
+    }
+
+    /// A struct for reading a zip file from a stream.
+    pub struct StreamingZipEntry<R> {
+        pub(crate) data: ZipFileData,
+        pub(crate) reader: R,
+    }
+
+    impl<R> Read for StreamingZipEntry<R>
+    where
+        R: Read,
+    {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            self.reader.read(buf)
+        }
+    }
+
+    impl<R> sealed_data::ArchiveData for StreamingZipEntry<R> {
+        fn data(&self) -> &ZipFileData {
+            &self.data
+        }
+    }
+
+    impl<R> ArchiveEntry for StreamingZipEntry<R> where R: Read {}
+
+    /// Additional metadata for the file.
+    #[derive(Debug)]
+    pub struct ZipStreamFileMetadata(ZipFileData);
+
+    impl sealed_data::ArchiveData for ZipStreamFileMetadata {
+        fn data(&self) -> &ZipFileData {
+            let Self(data) = self;
+            data
+        }
+    }
+
+    impl Read for ZipStreamFileMetadata {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            Ok(0)
+        }
+    }
+
+    impl ArchiveEntry for ZipStreamFileMetadata {}
+}

--- a/src/zipcrypto.rs
+++ b/src/zipcrypto.rs
@@ -202,7 +202,7 @@ impl<R: std::io::Read> std::io::Read for ZipCryptoReaderValid<R> {
     }
 }
 
-impl<R: std::io::Read> ZipCryptoReaderValid<R> {
+impl<R> ZipCryptoReaderValid<R> {
     /// Consumes this decoder, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.reader.file


### PR DESCRIPTION
*Moved from #207 after weird github errors.*

# Problem

I believe there are several shortcomings that necessitate a slight reimplementation of much of `src/read.rs`, some involving breaking API changes:

1. Propagating `Send` and/or `Sync` bounds from `R` to `ZipFile<R>` is literally impossible with the current public API that type-erases to `dyn Read`.
    - We could make two separate copies, one with `dyn Read + Send`, but that would be a lot of trouble and not worth it.
    - We could just assert that `R` is `Send` and always carry a `dyn Read + Send`, but that would be unsound and `unsafe` and could introduce memory unsafety.
2. `ZipFile` has a *lot* of stateful logic, including a `ZipFileReader::NoReader` state, even necessitating an `invalid_state()` helper method for error checking.
    - Notably (and imo inexcusably), `ZipFile` has a `Drop` impl which is *only* used when reading stream archives (to ensure we read out the rest of the entry from the stream), but this niche use case necessitates *every* reader struct in the crate to provide an `.into_inner()` method.
3. To underline the reason this `Drop` impl for `ZipFile` is a bad idea, **there is currently a bug in `ZipStreamReader` which drops the first `ZipStreamFileMetadata` entry,** because `read_zipfile_from_stream()` does not save the contents of the last `ZipLocalEntryBlock` it reads which has `spec::Magic::CENTRAL_DIRECTORY_HEADER_SIGNATURE`.
    - Basically, **streaming requires special handling, not being bolted onto `ZipFile`.**
4. Because streaming requires special handling and separate structs for entries, we also need to be able to get access to all the methods for accessing `ZipFileData` that we have on `ZipFile`, but for other structs. That's why this change introduces `EntryData`, which implements all the methods traditionally provided as member functions of `ZipFile`.
    - This means we don't need to go through the `ZipStreamVisitor` interface, and we can have direct control over when to iterate through each entry of the streaming zip file. That's what `zip::unstable::read::streaming` provides.
    - Importantly, `StreamingArchive` maintains the internal state necessary to retain the bytes of the first metadata entry after we go through all the local file entries, **fixing the bug in `ZipStreamReader` which drops the first metadata entry.** 
5. Finally, `ZipFileReader::Compressed(Box<Crc32Reader<Decompressor<io::BufReader<CryptoReader<'a>>>>>)` *always* goes through the logic for `CryptoReader`, when encrypted zip files are an *extremely* niche use case. We shouldn't be cluttering up our type definitions or our stack traces with encryption logic when most users are never going to touch it!
    - As an illustrative example, see our poor `Crc32Reader` at https://github.com/zip-rs/zip2/blob/3f6768ec5a51605bcb3e7a636c75ac98137223fb/src/crc32.rs#L15 which is completely unused if we're doing AE2 decryption. We shouldn't even be instantiating a `Crc32Reader` at all, and this change means we actually don't, instead of having to insert little workarounds and bolt on flags to disable stuff; see https://github.com/cosmicexplorer/zip/blob/04f6ced5f2197d0ef790774442e6371ab904229e/src/read.rs#L1329-L1345, where we do the more complex logic to instantiate the crypto reader in this new change:
```rust
        let final_reader = if data.encrypted {
            let crypto_variant = CryptoKeyValidationSource::from_data(data)?;
            let is_ae2_encrypted = crypto_variant.is_ae2_encrypted();
            let crypto_reader = crypto_variant.make_crypto_reader(password, content)?;
            let entry_reader =
                construct_decompressing_reader(&data.compression_method, crypto_reader)?;
            if is_ae2_encrypted {
                /* Ae2 voids crc checking: https://www.winzip.com/en/support/aes-encryption/ */
                CryptoEntryReader::Ae2Encrypted(entry_reader)
            } else {
                CryptoEntryReader::NonAe2Encrypted(NewCrc32Reader::new(entry_reader, data.crc32))
            }
        } else {
            /* Not encrypted, so do the same as in .by_index_generic(): */
            let entry_reader = construct_decompressing_reader(&data.compression_method, content)?;
            CryptoEntryReader::Unencrypted(NewCrc32Reader::new(entry_reader, data.crc32))
        };
```
- On the other hand, see https://github.com/cosmicexplorer/zip/blob/ea58b90cc205652a8285ebd9bf5a707d31bae254/src/read.rs#L1224-L1245, where we instantiate a *non*-crypto reader:
```rust
    /// Get a contained file by index
    pub fn by_index_generic(
        &mut self,
        file_number: usize,
    ) -> ZipResult<ZipEntry<'_, impl Read + '_>> {
        let Self {
            ref mut reader,
            ref shared,
            ..
        } = self;
        let (_, data) = shared
            .files
            .get_index(file_number)
            .ok_or(ZipError::FileNotFound)?;
        let content = find_entry_content_range(data, reader)?;
        let entry_reader = construct_decompressing_reader(&data.compression_method, content)?;
        let crc32_reader = NewCrc32Reader::new(entry_reader, data.crc32);
        Ok(ZipEntry {
            data,
            reader: crc32_reader,
        })
    }
```
That's the entire method! No jumping into decryption code paths for the much more common case of simple decompression with crc32 checking!

So that's my case for the API changes. We can do them in pieces, but I'm proposing this intentionally breaking change that I believe will improve the internal architecture and correctness, increase our ability to perform optimizations, and generate more flexible entry structs in our public API.

## More Specifically
*This section was copied from #207.*

As described in https://github.com/gyscos/zstd-rs/pull/288#issuecomment-2211438700, our usage of `&'a mut dyn Read` in `ZipFileReader` stops us from being able to impl `Send` or `Sync`, or generally to send a `ZipFile` into a separate thread than the one owning the `ZipArchive` it belongs to. While this is generally not an issue, as the single synchronous `Read + Seek` handle makes it difficult to farm out work to subthreads, for the purposes of #72, we would like to be able to reuse some code instead of creating an entirely separate implementation. *Note: #72 does not actually use this code, and this is a false argument. However, it is correct that other code using this crate, especially in `async` contexts, could really use the ability to impose `Send` bounds, which `ZipFile` is unable to satisfy.*

That brings us to the second set of issues, surrounding zipcrypto support:
- all of our readers go through the `CryptoReader` enum and the `make_crypto_reader()` method, even though zip crypto is a very uncommon use case,
- `ZipFile` itself contains some very complex mutable state with both a `ZipFileReader` and a `CryptoReader`, even though `ZipFileReader` itself also contains a `CryptoReader`,
- `Crc32Reader` has to maintain a special flag to disable CRC checking in the special case of AE2 encryption, which is a sign of a leaky abstraction and may easily introduce a failure to check CRC in other cases by accident in the future.

# Solution
Luckily, all of this becomes significantly easier without too many changes:
- Create `src/unstable/read.rs` to reimplement `read::ZipFile` with the new `unstable::read::ZipEntry`.
- Make `EntryReader` and `ZipEntry` with a parameterized reader type `R` instead of an internal `&'a mut dyn Read`.
- Make new versions of e.g. `ZipArchive::by_index()` returning `ZipResult<ZipEntry<'_, impl Read + '_>>` to avoid leaking internal structs while retaining the ability to rearrange the layout of our internal structs.
- Vastly improve readability of `CryptoReader` creation through `CryptoVariant`.

This also leads to a significantly improved refactoring of streaming support in the `streaming` submodule of `src/unstable/read.rs`.

# Result
zipcrypto support doesn't muck up the non-crypto methods, `ZipEntry` is now `Send`, and `src/unstable/read.rs` is significantly easier to read with equivalent functionality. This will have to be a breaking change in order to achieve `Send`-ability, but I believe the readability/maintainability is substantially improved with this change.