### PR TITLE
deps: Relax dependency versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,24 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  check_minimal_versions:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - name: resolve minimal versions
+        run: cargo -Z minimal-versions update
+      - name: check
+        run: cargo check --all-features
+      - name: test
+        run: cargo test --all-features
+
   style_and_docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,9 @@ bencher = "0.1.5"
 getrandom = { version = "0.2.15", features = ["js", "std"] }
 walkdir = "2.5.0"
 time = { workspace = true, features = ["formatting", "macros"] }
-anyhow = "1"
+anyhow = "1.0.60"
 clap = { version = "=4.4.18", features = ["derive"] }
-tempfile = "3"
+tempfile = "3.8"
 
 [features]
 aes-crypto = ["aes", "constant_time_eq", "hmac", "pbkdf2", "sha1", "rand", "zeroize"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,29 +23,29 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
-time = { version = "0.3.36", default-features = false }
+time = { version = "0.3.1", default-features = false }
 
 [dependencies]
-aes = { version = "0.8.4", optional = true }
-bzip2 = { version = "0.4.4", optional = true }
-chrono = { version = "0.4.38", optional = true }
-constant_time_eq = { version = "0.3.1", optional = true }
-crc32fast = "1.4.2"
-displaydoc = { version = "0.2.5", default-features = false }
-flate2 = { version = "1.0.33", default-features = false, optional = true }
+aes = { version = "0.8.0", optional = true }
+bzip2 = { version = "0.4.3", optional = true }
+chrono = { version = "0.4.0", optional = true }
+constant_time_eq = { version = "0.3.0", optional = true }
+crc32fast = "1.4.0"
+displaydoc = { version = "0.2.0", default-features = false }
+flate2 = { version = "1.0.0", default-features = false, optional = true }
 indexmap = "2"
-hmac = { version = "0.12.1", optional = true, features = ["reset"] }
-memchr = "2.7.4"
-pbkdf2 = { version = "0.12.2", optional = true }
-rand = { version = "0.8.5", optional = true }
-sha1 = { version = "0.10.6", optional = true }
-thiserror = "2.0.3"
+hmac = { version = "0.12.0", optional = true, features = ["reset"] }
+memchr = "2.7"
+pbkdf2 = { version = "0.12", optional = true }
+rand = { version = "0.8", optional = true }
+sha1 = { version = "0.10", optional = true }
+thiserror = "2"
 time = { workspace = true, optional = true, features = [
     "std",
 ] }
-zeroize = { version = "1.8.1", optional = true, features = ["zeroize_derive"] }
-zstd = { version = "0.13.2", optional = true, default-features = false }
-zopfli = { version = "0.8.1", optional = true }
+zeroize = { version = "1.8", optional = true, features = ["zeroize_derive"] }
+zstd = { version = "0.13", optional = true, default-features = false }
+zopfli = { version = "0.8", optional = true }
 deflate64 = { version = "0.1.9", optional = true }
 lzma-rs = { version = "0.3.0", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 time = { version = "0.3.1", default-features = false }
 
 [dependencies]
-aes = { version = "0.8.0", optional = true }
+aes = { version = "0.8", optional = true }
 bzip2 = { version = "0.4.3", optional = true }
-chrono = { version = "0.4.0", optional = true }
-constant_time_eq = { version = "0.3.0", optional = true }
-crc32fast = "1.4.0"
-displaydoc = { version = "0.2.0", default-features = false }
-flate2 = { version = "1.0.0", default-features = false, optional = true }
+chrono = { version = "0.4", optional = true }
+constant_time_eq = { version = "0.3", optional = true }
+crc32fast = "1.4"
+displaydoc = { version = "0.2", default-features = false }
+flate2 = { version = "1.0", default-features = false, optional = true }
 indexmap = "2"
-hmac = { version = "0.12.0", optional = true, features = ["reset"] }
+hmac = { version = "0.12", optional = true, features = ["reset"] }
 memchr = "2.7"
 pbkdf2 = { version = "0.12", optional = true }
 rand = { version = "0.8", optional = true }
@@ -47,7 +47,7 @@ zeroize = { version = "1.8", optional = true, features = ["zeroize_derive"] }
 zstd = { version = "0.13", optional = true, default-features = false }
 zopfli = { version = "0.8", optional = true }
 deflate64 = { version = "0.1.9", optional = true }
-lzma-rs = { version = "0.3.0", default-features = false, optional = true }
+lzma-rs = { version = "0.3", default-features = false, optional = true }
 
 [target.'cfg(any(all(target_arch = "arm", target_pointer_width = "32"), target_arch = "mips", target_arch = "powerpc"))'.dependencies]
 crossbeam-utils = "0.8.20"
@@ -58,7 +58,7 @@ arbitrary = { version = "1.3.2", features = ["derive"] }
 [dev-dependencies]
 bencher = "0.1.5"
 getrandom = { version = "0.2.15", features = ["js", "std"] }
-walkdir = "2.5.0"
+walkdir = "2.5"
 time = { workspace = true, features = ["formatting", "macros"] }
 anyhow = "1.0.60"
 clap = { version = "=4.4.18", features = ["derive"] }


### PR DESCRIPTION
Hi,

I'm considering using zip2 in a project that has a downstream pin to `aes =0.8.3` but zip2 requires `aes ^0.8.4`.

It seems like your current strategy is to periodically bump dependency versions to the latest versions, even for SemVer-compatible releases. Is this a measure to ensure that security-critical bugfixes are always picked up when using recent versions of zip2? If not: Would you be fine with more relaxed version bounds for zip2's dependencies?

In this PR I've added a CI job that tests the project with the lowest-compatible dependency versions (`cargo update -Zminimal-versions`), bumped an outdated dev-dependency that breaks builds with minimal versions, and relaxed versions of the project's dependencies where appropriate.

Feel free to merge or close :upside_down_face: 
Thanks!

<!-- 
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Please make sure your PR's target repo is `zip-rs/zip2` and not `zip-rs/zip-old`. The latter
  repo is no longer maintained, and I will archive it after closing the pre-existing issues.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start 
  with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
  This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged.

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->
