### PR TITLE
fix: clippy::needless_as_bytes warning

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -831,7 +831,7 @@ impl ZipFileData {
             extra_field_length: extra_field_len.checked_add(central_extra_field_len).ok_or(
                 ZipError::InvalidArchive("Extra field length in central directory exceeds 64KiB"),
             )?,
-            file_comment_length: self.file_comment.as_bytes().len().try_into().unwrap(),
+            file_comment_length: self.file_comment.len().try_into().unwrap(),
             disk_number: 0,
             internal_file_attributes: 0,
             external_file_attributes: self.external_attributes,

--- a/src/write.rs
+++ b/src/write.rs
@@ -911,9 +911,8 @@ impl<W: Write + Seek> ZipWriter<W> {
             ),
             _ => (options.compression_method, None),
         };
-        let header_end = header_start
-            + size_of::<ZipLocalEntryBlock>() as u64
-            + name.to_string().as_bytes().len() as u64;
+        let header_end =
+            header_start + size_of::<ZipLocalEntryBlock>() as u64 + name.to_string().len() as u64;
         if options.alignment > 1 {
             let extra_data_end = header_end + extra_data.len() as u64;
             let align = options.alignment as u64;


### PR DESCRIPTION
This fixes another clippy warning that was causing the CI to fail, including #258!?