### PR TITLE
chore: release v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.2.3](https://github.com/zip-rs/zip2/compare/v2.2.2...v2.2.3) - 2025-02-25
+
+### <!-- 2 -->🚜 Refactor
+
+- Change the inner structure of `DateTime` (#267)
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+
+- cargo fix --edition
+
 ## [2.2.2](https://github.com/zip-rs/zip2/compare/v2.2.1...v2.2.2) - 2024-12-16
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "2.2.2"
+version = "2.2.3"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION



## 🤖 New release

* `zip`: 2.2.2 -> 2.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.2.3](https://github.com/zip-rs/zip2/compare/v2.2.2...v2.2.3) - 2025-02-25

### <!-- 2 -->🚜 Refactor

- Change the inner structure of `DateTime` (#267)

### <!-- 7 -->⚙️ Miscellaneous Tasks

- cargo fix --edition
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).