### PR TITLE
fix: improve error message for duplicated file

### DIFF
--- a/fuzz_write/src/main.rs
+++ b/fuzz_write/src/main.rs
@@ -325,7 +325,7 @@ impl FuzzTestCase<'_> {
         }
         if final_reopen {
             writeln!(stringifier, "let _ = writer.finish_into_readable()?;")
-                .map_err(|_| ZipError::InvalidArchive(""))?;
+                .map_err(|_| ZipError::InvalidArchive("".into()))?;
             let _ = writer.finish_into_readable()?;
         }
         Ok(())

--- a/src/extra_fields/zipinfo_utf8.rs
+++ b/src/extra_fields/zipinfo_utf8.rs
@@ -1,4 +1,4 @@
-use crate::result::{ZipError, ZipResult};
+use crate::result::{invalid, ZipResult};
 use crate::unstable::LittleEndianReadExt;
 use core::mem::size_of;
 use std::io::Read;
@@ -18,9 +18,7 @@ impl UnicodeExtraField {
         crc32.update(ascii_field);
         let actual_crc32 = crc32.finalize();
         if self.crc32 != actual_crc32 {
-            return Err(ZipError::InvalidArchive(
-                "CRC32 checksum failed on Unicode extra field",
-            ));
+            return Err(invalid!("CRC32 checksum failed on Unicode extra field"));
         }
         Ok(self.content)
     }
@@ -34,7 +32,7 @@ impl UnicodeExtraField {
         let crc32 = reader.read_u32_le()?;
         let content_len = (len as usize)
             .checked_sub(size_of::<u8>() + size_of::<u32>())
-            .ok_or(ZipError::InvalidArchive("Unicode extra field is too small"))?;
+            .ok_or(invalid!("Unicode extra field is too small"))?;
         let mut content = vec![0u8; content_len].into_boxed_slice();
         reader.read_exact(&mut content)?;
         Ok(Self { crc32, content })

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -94,7 +94,7 @@ impl<R: Read> ZipStreamReader<R> {
                     use super::ZipError;
                     let filepath = metadata
                         .enclosed_name()
-                        .ok_or(ZipError::InvalidArchive("Invalid file path"))?;
+                        .ok_or(crate::result::invalid!("Invalid file path"))?;
 
                     let outpath = self.0.join(filepath);
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -98,6 +98,10 @@ impl fmt::Display for DateTimeRangeError {
 
 impl Error for DateTimeRangeError {}
 
+pub(crate) fn invalid_archive<M: Into<Cow<'static, str>>>(message: M) -> ZipError {
+    ZipError::InvalidArchive(message.into())
+}
+
 pub(crate) const fn invalid_archive_const(message: &'static str) -> ZipError {
     ZipError::InvalidArchive(Cow::Borrowed(message))
 }
@@ -105,6 +109,9 @@ pub(crate) const fn invalid_archive_const(message: &'static str) -> ZipError {
 macro_rules! invalid {
     ($message:literal) => {
         crate::result::invalid_archive_const($message)
+    };
+    ($($arg:tt)*) => {
+        crate::result::invalid_archive(format!($($arg)*))
     };
 }
 pub(crate) use invalid;

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,6 +5,7 @@
 use displaydoc::Display;
 use thiserror::Error;
 
+use std::borrow::Cow;
 use std::error::Error;
 use std::fmt;
 use std::io;
@@ -22,7 +23,7 @@ pub enum ZipError {
     Io(#[from] io::Error),
 
     /// invalid Zip archive: {0}
-    InvalidArchive(&'static str),
+    InvalidArchive(Cow<'static, str>),
 
     /// unsupported Zip archive: {0}
     UnsupportedArchive(&'static str),
@@ -65,13 +66,13 @@ impl From<ZipError> for io::Error {
 
 impl From<DateTimeRangeError> for ZipError {
     fn from(_: DateTimeRangeError) -> Self {
-        ZipError::InvalidArchive("Invalid date or time")
+        invalid!("Invalid date or time")
     }
 }
 
 impl From<FromUtf8Error> for ZipError {
     fn from(_: FromUtf8Error) -> Self {
-        ZipError::InvalidArchive("Invalid UTF-8")
+        invalid!("Invalid UTF-8")
     }
 }
 
@@ -96,3 +97,14 @@ impl fmt::Display for DateTimeRangeError {
 }
 
 impl Error for DateTimeRangeError {}
+
+pub(crate) const fn invalid_archive_const(message: &'static str) -> ZipError {
+    ZipError::InvalidArchive(Cow::Borrowed(message))
+}
+
+macro_rules! invalid {
+    ($message:literal) => {
+        crate::result::invalid_archive_const($message)
+    };
+}
+pub(crate) use invalid;

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, OnceLock};
 #[cfg(feature = "chrono")]
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 
-use crate::result::{ZipError, ZipResult};
+use crate::result::{invalid, ZipError, ZipResult};
 use crate::spec::{self, FixedSizeBlock, Pod};
 
 pub(crate) mod ffi {
@@ -799,7 +799,7 @@ impl ZipFileData {
         let extra_field_length: u16 = self
             .extra_field_len()
             .try_into()
-            .map_err(|_| ZipError::InvalidArchive("Extra data field is too large"))?;
+            .map_err(|_| invalid!("Extra data field is too large"))?;
 
         let last_modified_time = self
             .last_modified_time
@@ -848,7 +848,7 @@ impl ZipFileData {
                 .unwrap(),
             file_name_length: self.file_name_raw.len().try_into().unwrap(),
             extra_field_length: extra_field_len.checked_add(central_extra_field_len).ok_or(
-                ZipError::InvalidArchive("Extra field length in central directory exceeds 64KiB"),
+                invalid!("Extra field length in central directory exceeds 64KiB"),
             )?,
             file_comment_length: self.file_comment.len().try_into().unwrap(),
             disk_number: 0,
@@ -904,8 +904,7 @@ impl FixedSizeBlock for ZipCentralEntryBlock {
         self.magic
     }
 
-    const WRONG_MAGIC_ERROR: ZipError =
-        ZipError::InvalidArchive("Invalid Central Directory header");
+    const WRONG_MAGIC_ERROR: ZipError = invalid!("Invalid Central Directory header");
 
     to_and_from_le![
         (magic, spec::Magic),
@@ -954,7 +953,7 @@ impl FixedSizeBlock for ZipLocalEntryBlock {
         self.magic
     }
 
-    const WRONG_MAGIC_ERROR: ZipError = ZipError::InvalidArchive("Invalid local file header");
+    const WRONG_MAGIC_ERROR: ZipError = invalid!("Invalid local file header");
 
     to_and_from_le![
         (magic, spec::Magic),

--- a/src/write.rs
+++ b/src/write.rs
@@ -1045,7 +1045,7 @@ impl<W: Write + Seek> ZipWriter<W> {
 
     fn insert_file_data(&mut self, file: ZipFileData) -> ZipResult<usize> {
         if self.files.contains_key(&file.file_name) {
-            return Err(invalid!("Duplicate filename"));
+            return Err(invalid!("Duplicate filename: {}", file.file_name));
         }
         let name = file.file_name.to_owned();
         self.files.insert(name.clone(), file);

--- a/src/write.rs
+++ b/src/write.rs
@@ -4,7 +4,7 @@
 use crate::aes::AesWriter;
 use crate::compression::CompressionMethod;
 use crate::read::{parse_single_extra_field, Config, ZipArchive, ZipFile};
-use crate::result::{ZipError, ZipResult};
+use crate::result::{invalid, ZipError, ZipResult};
 use crate::spec::{self, FixedSizeBlock, Zip32CDEBlock};
 #[cfg(feature = "aes-crypto")]
 use crate::types::AesMode;
@@ -177,7 +177,7 @@ pub(crate) mod zip_writer {
 }
 #[doc(inline)]
 pub use self::sealed::FileOptionExtension;
-use crate::result::ZipError::{InvalidArchive, UnsupportedArchive};
+use crate::result::ZipError::UnsupportedArchive;
 use crate::unstable::path_to_string;
 use crate::unstable::LittleEndianWriteExt;
 use crate::write::GenericZipWriter::{Closed, Storer};
@@ -290,9 +290,7 @@ impl ExtendedFileOptions {
     ) -> ZipResult<()> {
         let len = data.len() + 4;
         if self.extra_data.len() + self.central_extra_data.len() + len > u16::MAX as usize {
-            Err(InvalidArchive(
-                "Extra data field would be longer than allowed",
-            ))
+            Err(invalid!("Extra data field would be longer than allowed"))
         } else {
             let field = if central_only {
                 &mut self.central_extra_data
@@ -675,7 +673,7 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     pub fn deep_copy_file(&mut self, src_name: &str, dest_name: &str) -> ZipResult<()> {
         self.finish_file()?;
         if src_name == dest_name || self.files.contains_key(dest_name) {
-            return Err(InvalidArchive("That file already exists"));
+            return Err(invalid!("That file already exists"));
         }
         let write_position = self.inner.get_plain().stream_position()?;
         let src_index = self.index_by_name(src_name)?;
@@ -974,8 +972,8 @@ impl<W: Write + Seek> ZipWriter<W> {
         let extra_data_len = extra_data.len();
         if let Some(data) = central_extra_data {
             if extra_data_len + data.len() > u16::MAX as usize {
-                return Err(InvalidArchive(
-                    "Extra data and central extra data must be less than 64KiB when combined",
+                return Err(invalid!(
+                    "Extra data and central extra data must be less than 64KiB when combined"
                 ));
             }
             ExtendedFileOptions::validate_extra_data(data, true)?;
@@ -1047,7 +1045,7 @@ impl<W: Write + Seek> ZipWriter<W> {
 
     fn insert_file_data(&mut self, file: ZipFileData) -> ZipResult<usize> {
         if self.files.contains_key(&file.file_name) {
-            return Err(InvalidArchive("Duplicate filename"));
+            return Err(invalid!("Duplicate filename"));
         }
         let name = file.file_name.to_owned();
         self.files.insert(name.clone(), file);
@@ -1594,7 +1592,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     pub fn shallow_copy_file(&mut self, src_name: &str, dest_name: &str) -> ZipResult<()> {
         self.finish_file()?;
         if src_name == dest_name {
-            return Err(InvalidArchive("Trying to copy a file to itself"));
+            return Err(invalid!("Trying to copy a file to itself"));
         }
         let src_index = self.index_by_name(src_name)?;
         let mut dest_data = self.files[src_index].to_owned();
@@ -1959,8 +1957,8 @@ fn update_local_zip64_extra_field<T: Write + Seek>(
     writer: &mut T,
     file: &mut ZipFileData,
 ) -> ZipResult<()> {
-    let block = file.zip64_extra_field_block().ok_or(InvalidArchive(
-        "Attempted to update a nonexistent ZIP64 extra field",
+    let block = file.zip64_extra_field_block().ok_or(invalid!(
+        "Attempted to update a nonexistent ZIP64 extra field"
     ))?;
 
     let zip64_extra_field_start = file.header_start


### PR DESCRIPTION
<!-- 
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Please make sure your PR's target repo is `zip-rs/zip2` and not `zip-rs/zip-old`. The latter
  repo is no longer maintained, and I will archive it after closing the pre-existing issues.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start 
  with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
  This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged.

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

This RP include duplicated filename in returned `ZipResult`. Also introduce a macro `invalid!` to help construct `ZipError::InvalidArchive`.

Close #127 
