### PR TITLE
style: lint fuzz projects in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,12 +88,14 @@ jobs:
       - style_and_docs
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain add nightly && rustup default nightly
+      - run: rustup toolchain add nightly && rustup default nightly && rustup component add clippy
 
       - run: cargo install cargo-afl
 
       - name: cargo afl system-config
         run: cargo afl system-config
+      - name: clippy
+        run: cargo afl clippy --all-features --manifest-path ${{ github.workspace }}/fuzz_read/Cargo.toml -- -D warnings
       - name: compile fuzz
         run: cargo afl build --all-features --manifest-path ${{ github.workspace }}/fuzz_read/Cargo.toml
       - name: run fuzz
@@ -136,12 +138,14 @@ jobs:
       - style_and_docs
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain add nightly && rustup default nightly
+      - run: rustup toolchain add nightly && rustup default nightly && rustup component add clippy
 
       - run: cargo install cargo-afl
 
       - name: cargo afl system-config
         run: cargo afl system-config
+      - name: clippy
+        run: cargo afl clippy --no-default-features --manifest-path ${{ github.workspace }}/fuzz_read/Cargo.toml -- -D warnings
       - name: compile fuzz
         run: cargo afl build --manifest-path ${{ github.workspace }}/fuzz_read/Cargo.toml
       - name: run fuzz
@@ -176,12 +180,14 @@ jobs:
       - style_and_docs
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain add nightly && rustup default nightly
+      - run: rustup toolchain add nightly && rustup default nightly && rustup component add clippy
 
       - run: cargo install cargo-afl
 
       - name: cargo afl system-config
         run: cargo afl system-config
+      - name: clippy
+        run: cargo afl clippy --all-features --manifest-path ${{ github.workspace }}/fuzz_write/Cargo.toml -- -D warnings
       - name: compile fuzz
         run: cargo afl build --all-features --manifest-path ${{ github.workspace }}/fuzz_write/Cargo.toml
       - name: run fuzz
@@ -224,12 +230,14 @@ jobs:
       - style_and_docs
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain add nightly && rustup default nightly
+      - run: rustup toolchain add nightly && rustup default nightly && rustup component add clippy
 
       - run: cargo install cargo-afl
 
       - name: cargo afl system-config
         run: cargo afl system-config
+      - name: clippy
+        run: cargo afl clippy --no-default-features --manifest-path ${{ github.workspace }}/fuzz_write/Cargo.toml -- -D warnings
       - name: compile fuzz
         run: cargo afl build --all-features --manifest-path ${{ github.workspace }}/fuzz_write/Cargo.toml
       - name: run fuzz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain add nightly && rustup default nightly && rustup component add rustfmt
-
-      - run: cargo fmt --all -- --check
+      - name: fmt
+        run: cargo fmt --all -- --check
+      - name: fmt fuzz_read
+        run: cargo fmt --manifest-path fuzz_read/Cargo.toml -- --check
+      - name: fmt fuzz_write
+        run: cargo fmt --manifest-path fuzz_write/Cargo.toml -- --check
 
   check_minimal_versions:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/fuzz_write/src/main.rs
+++ b/fuzz_write/src/main.rs
@@ -49,11 +49,11 @@ pub struct FileOperation<'k> {
     // 'abort' flag is separate, to prevent trying to copy an aborted file
 }
 
-impl<'k> FileOperation<'k> {
+impl FileOperation<'_> {
     fn get_path(&self) -> Option<PathBuf> {
         match &self.basic {
             BasicFileOperation::SetArchiveComment(_) => None,
-            BasicFileOperation::WriteDirectory(_) => Some(self.path.join("/")),
+            BasicFileOperation::WriteDirectory(_) => Some(self.path.join("")),
             BasicFileOperation::MergeWithOtherFile { operations, .. } => operations
                 .iter()
                 .flat_map(|(op, abort)| if !abort { op.get_path() } else { None })
@@ -84,9 +84,9 @@ fn deduplicate_paths(copy: &mut PathBuf, original: &PathBuf) {
     }
 }
 
-fn do_operation<'k>(
+fn do_operation(
     writer: &mut zip::ZipWriter<Cursor<Vec<u8>>>,
-    operation: FileOperation<'k>,
+    operation: FileOperation<'_>,
     abort: bool,
     flush_on_finish_file: bool,
     files_added: &mut usize,
@@ -125,7 +125,7 @@ fn do_operation<'k>(
             writer.start_file_from_path(&*path, options)?;
             for chunk in contents.iter() {
                 writeln!(stringifier, "writer.write_all(&{:?})?;", chunk)?;
-                writer.write_all(&chunk)?;
+                writer.write_all(chunk)?;
             }
             *files_added += 1;
         }
@@ -298,7 +298,7 @@ fn do_operation<'k>(
     Ok(())
 }
 
-impl<'k> FuzzTestCase<'k> {
+impl FuzzTestCase<'_> {
     fn execute(self, stringifier: &mut impl Write, panic_on_error: bool) -> ZipResult<()> {
         let mut initial_junk = Cursor::new(self.initial_junk.into_vec());
         initial_junk.seek(SeekFrom::End(0))?;
@@ -332,7 +332,7 @@ impl<'k> FuzzTestCase<'k> {
     }
 }
 
-impl<'k> Debug for FuzzTestCase<'k> {
+impl Debug for FuzzTestCase<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if self.initial_junk.is_empty() {
             writeln!(


### PR DESCRIPTION
<!-- 
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Please make sure your PR's target repo is `zip-rs/zip2` and not `zip-rs/zip-old`. The latter
  repo is no longer maintained, and I will archive it after closing the pre-existing issues.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start 
  with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
  This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged.

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

This PR adds steps to run `cargo fmt` and `cargo clippy` to `fuzz_write` and `fuzz_read`, also fixed some issues found by `fmt` and `clippy`.