### PR TITLE
chore: Fix clippy and cargo fmt warnings

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -12,9 +12,7 @@ pub(crate) fn simplified_components(input: &Path) -> Option<Vec<&OsStr>> {
         match component {
             Component::Prefix(_) | Component::RootDir => return None,
             Component::ParentDir => {
-                if out.pop().is_none() {
-                    return None;
-                }
+                out.pop()?;
             }
             Component::Normal(_) => out.push(component.as_os_str()),
             Component::CurDir => (),

--- a/src/read.rs
+++ b/src/read.rs
@@ -480,6 +480,7 @@ pub(crate) fn make_symlink(outpath: &PathBuf, target: Vec<u8>) -> ZipResult<()> 
         } else {
             false
         };
+        let target = Path::new(&target);
         if target_is_dir {
             std::os::windows::fs::symlink_dir(target, outpath.as_path())?;
         } else {

--- a/src/read.rs
+++ b/src/read.rs
@@ -472,7 +472,8 @@ pub(crate) fn make_symlink(outpath: &Path, target: Vec<u8>) -> ZipResult<()> {
             return Err(ZipError::InvalidArchive("Invalid UTF-8 as symlink target"));
         };
         let target_str = target.as_str();
-        let target_is_dir_from_archive = self.shared.files.contains_key(target_str) && is_dir(target_str);
+        let target_is_dir_from_archive =
+            self.shared.files.contains_key(target_str) && is_dir(target_str);
         let target_is_dir = if target_is_dir_from_archive {
             true
         } else if let Ok(meta) = std::fs::metadata(target) {

--- a/src/read.rs
+++ b/src/read.rs
@@ -449,7 +449,7 @@ pub(crate) fn make_reader(
     ))))
 }
 
-pub(crate) fn make_symlink(outpath: &PathBuf, target: Vec<u8>) -> ZipResult<()> {
+pub(crate) fn make_symlink(outpath: &Path, target: Vec<u8>) -> ZipResult<()> {
     #[cfg(not(any(unix, windows)))]
     {
         let output = File::create(outpath.as_path());
@@ -464,7 +464,7 @@ pub(crate) fn make_symlink(outpath: &PathBuf, target: Vec<u8>) -> ZipResult<()> 
 
     #[cfg(unix)]
     {
-        std::os::unix::fs::symlink(target, outpath.as_path())?;
+        std::os::unix::fs::symlink(target, outpath)?;
     }
     #[cfg(windows)]
     {

--- a/src/read.rs
+++ b/src/read.rs
@@ -449,7 +449,11 @@ pub(crate) fn make_reader(
     ))))
 }
 
-pub(crate) fn make_symlink<T>(outpath: &Path, target: &[u8], #[allow(unused)] existing_files: &IndexMap<Box<str>, T>) -> ZipResult<()> {
+pub(crate) fn make_symlink<T>(
+    outpath: &Path,
+    target: &[u8],
+    #[allow(unused)] existing_files: &IndexMap<Box<str>, T>
+) -> ZipResult<()> {
     #[cfg(not(any(unix, windows)))]
     {
         let output = File::create(outpath);
@@ -457,7 +461,7 @@ pub(crate) fn make_symlink<T>(outpath: &Path, target: &[u8], #[allow(unused)] ex
         continue;
     }
 
-    let Ok(target_str) = std::str::from_utf8(&target) else {
+    let Ok(target_str) = std::str::from_utf8(target) else {
         return Err(ZipError::InvalidArchive("Invalid UTF-8 as symlink target"));
     };
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -471,7 +471,8 @@ pub(crate) fn make_symlink(outpath: &Path, target: Vec<u8>) -> ZipResult<()> {
         let Ok(target) = String::from_utf8(target) else {
             return Err(ZipError::InvalidArchive("Invalid UTF-8 as symlink target"));
         };
-        let target_is_dir_from_archive = self.shared.files.contains_key(target.as_str()) && is_dir(target.as_str());
+        let target_str = target.as_str();
+        let target_is_dir_from_archive = self.shared.files.contains_key(target_str) && is_dir(target_str);
         let target_is_dir = if target_is_dir_from_archive {
             true
         } else if let Ok(meta) = std::fs::metadata(target) {

--- a/src/read.rs
+++ b/src/read.rs
@@ -480,7 +480,7 @@ pub(crate) fn make_symlink(outpath: &PathBuf, target: Vec<u8>) -> ZipResult<()> 
         } else {
             false
         };
-        let target = Path::new(&target);
+        let target = Path::new(OsStr::new(&target));
         if target_is_dir {
             std::os::windows::fs::symlink_dir(target, outpath.as_path())?;
         } else {

--- a/src/read.rs
+++ b/src/read.rs
@@ -449,7 +449,7 @@ pub(crate) fn make_reader(
     ))))
 }
 
-pub(crate) fn make_symlink(outpath: &Path, target: &[u8]) -> ZipResult<()> {
+pub(crate) fn make_symlink<T>(outpath: &Path, target: &[u8], #[allow(unused)] existing_files: &IndexMap<Box<str>, T>) -> ZipResult<()> {
     #[cfg(not(any(unix, windows)))]
     {
         let output = File::create(outpath);
@@ -469,7 +469,7 @@ pub(crate) fn make_symlink(outpath: &Path, target: &[u8]) -> ZipResult<()> {
     {
         let target = Path::new(OsStr::new(&target_str));
         let target_is_dir_from_archive =
-            self.shared.files.contains_key(target_str) && is_dir(target_str);
+            existing_files.contains_key(target_str) && is_dir(target_str);
         let target_is_dir = if target_is_dir_from_archive {
             true
         } else if let Ok(meta) = std::fs::metadata(target) {
@@ -813,7 +813,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             drop(file);
 
             if let Some(target) = symlink_target {
-                make_symlink(&outpath, &target)?;
+                make_symlink(&outpath, &target, &self.shared.files)?;
                 continue;
             }
             let mut file = self.by_index(i)?;

--- a/src/read.rs
+++ b/src/read.rs
@@ -452,19 +452,17 @@ pub(crate) fn make_reader(
 pub(crate) fn make_symlink<T>(
     outpath: &Path,
     target: &[u8],
-    #[allow(unused)] existing_files: &IndexMap<Box<str>, T>
+    #[allow(unused)] existing_files: &IndexMap<Box<str>, T>,
 ) -> ZipResult<()> {
-    #[cfg(not(any(unix, windows)))]
-    {
-        let output = File::create(outpath);
-        output.write_all(target)?;
-        continue;
-    }
-
     let Ok(target_str) = std::str::from_utf8(target) else {
         return Err(ZipError::InvalidArchive("Invalid UTF-8 as symlink target"));
     };
 
+    #[cfg(not(any(unix, windows)))]
+    {
+        let output = File::create(outpath);
+        output.write_all(target)?;
+    }
     #[cfg(unix)]
     {
         std::os::unix::fs::symlink(Path::new(&target_str), outpath)?;

--- a/src/read.rs
+++ b/src/read.rs
@@ -457,7 +457,7 @@ pub(crate) fn make_symlink(outpath: &Path, target: &[u8]) -> ZipResult<()> {
         continue;
     }
 
-    let Ok(target_str) = str::from_utf8(&target) else {
+    let Ok(target_str) = std::str::from_utf8(&target) else {
         return Err(ZipError::InvalidArchive("Invalid UTF-8 as symlink target"));
     };
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -471,20 +471,18 @@ pub(crate) fn make_symlink(outpath: &Path, target: Vec<u8>) -> ZipResult<()> {
         let Ok(target) = String::from_utf8(target) else {
             return Err(ZipError::InvalidArchive("Invalid UTF-8 as symlink target"));
         };
-        let target = target.into_boxed_str();
-        let target_is_dir_from_archive = self.shared.files.contains_key(&target) && is_dir(&target);
+        let target_is_dir_from_archive = self.shared.files.contains_key(target.as_str()) && is_dir(target.as_str());
         let target_is_dir = if target_is_dir_from_archive {
             true
-        } else if let Ok(meta) = std::fs::metadata(&target) {
+        } else if let Ok(meta) = std::fs::metadata(target) {
             meta.is_dir()
         } else {
             false
         };
-        let target = Path::new(OsStr::new(&target));
         if target_is_dir {
-            std::os::windows::fs::symlink_dir(target, outpath.as_path())?;
+            std::os::windows::fs::symlink_dir(target, outpath)?;
         } else {
-            std::os::windows::fs::symlink_file(target, outpath.as_path())?;
+            std::os::windows::fs::symlink_file(target, outpath)?;
         }
     }
     Ok(())

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -1,12 +1,12 @@
-use std::fs;
-use std::io::{self, Read};
-use std::path::{Path, PathBuf};
-use indexmap::IndexMap;
 use super::{
     central_header_to_zip_file_inner, make_symlink, read_zipfile_from_stream, ZipCentralEntryBlock,
     ZipFile, ZipFileData, ZipResult,
 };
 use crate::spec::FixedSizeBlock;
+use indexmap::IndexMap;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
 
 /// Stream decoder for zip.
 #[derive(Debug)]
@@ -105,7 +105,10 @@ impl<R: Read> ZipStreamReader<R> {
             }
         }
 
-        self.visit(&mut Extractor(directory.as_ref().canonicalize()?, IndexMap::new()))
+        self.visit(&mut Extractor(
+            directory.as_ref().canonicalize()?,
+            IndexMap::new(),
+        ))
     }
 }
 

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -66,7 +66,7 @@ impl<R: Read> ZipStreamReader<R> {
                 if file.is_symlink() {
                     let mut target = Vec::with_capacity(file.size() as usize);
                     file.read_to_end(&mut target)?;
-                    make_symlink(&outpath, target)?;
+                    make_symlink(&outpath, &target)?;
                     return Ok(());
                 }
 

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use indexmap::IndexMap;
 use super::{
     central_header_to_zip_file_inner, make_symlink, read_zipfile_from_stream, ZipCentralEntryBlock,
-    ZipError, ZipFile, ZipFileData, ZipResult,
+    ZipFile, ZipFileData, ZipResult,
 };
 use crate::spec::FixedSizeBlock;
 
@@ -88,6 +88,7 @@ impl<R: Read> ZipStreamReader<R> {
             ) -> ZipResult<()> {
                 #[cfg(unix)]
                 {
+                    use super::ZipError;
                     let filepath = metadata
                         .enclosed_name()
                         .ok_or(ZipError::InvalidArchive("Invalid file path"))?;

--- a/src/write.rs
+++ b/src/write.rs
@@ -347,8 +347,7 @@ impl ExtendedFileOptions {
             {
                 use crate::unstable::LittleEndianReadExt;
                 let header_id = data.read_u16_le()?;
-                if EXTRA_FIELD_MAPPING.contains(&header_id)
-                {
+                if EXTRA_FIELD_MAPPING.contains(&header_id) {
                     return Err(ZipError::Io(io::Error::new(
                         io::ErrorKind::Other,
                         format!(

--- a/src/write.rs
+++ b/src/write.rs
@@ -347,9 +347,7 @@ impl ExtendedFileOptions {
             {
                 use crate::unstable::LittleEndianReadExt;
                 let header_id = data.read_u16_le()?;
-                if EXTRA_FIELD_MAPPING
-                    .iter()
-                    .any(|&mapped| mapped == header_id)
+                if EXTRA_FIELD_MAPPING.contains(header_id)
                 {
                     return Err(ZipError::Io(io::Error::new(
                         io::ErrorKind::Other,

--- a/src/write.rs
+++ b/src/write.rs
@@ -347,7 +347,7 @@ impl ExtendedFileOptions {
             {
                 use crate::unstable::LittleEndianReadExt;
                 let header_id = data.read_u16_le()?;
-                if EXTRA_FIELD_MAPPING.contains(header_id)
+                if EXTRA_FIELD_MAPPING.contains(&header_id)
                 {
                     return Err(ZipError::Io(io::Error::new(
                         io::ErrorKind::Other,


### PR DESCRIPTION
<!-- 
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Please make sure your PR's target repo is `zip-rs/zip2` and not `zip-rs/zip-old`. The latter
  repo is no longer maintained, and I will archive it after closing the pre-existing issues.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start 
  with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
  This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged.

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->
