### PR TITLE
chore: release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.5.0](https://github.com/zip-rs/zip2/compare/v2.4.2...v2.5.0) - 2025-03-23
+
+### <!-- 0 -->🚀 Features
+
+- Add support for `time::PrimitiveDateTime` ([#322](https://github.com/zip-rs/zip2/pull/322))
+- Add `jiff` integration ([#323](https://github.com/zip-rs/zip2/pull/323))
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- improve error message for duplicated file ([#277](https://github.com/zip-rs/zip2/pull/277))
+
 ## [2.4.2](https://github.com/zip-rs/zip2/compare/v2.4.1...v2.4.2) - 2025-03-18
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "2.4.2"
+version = "2.5.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION



## 🤖 New release

* `zip`: 2.4.2 -> 2.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.5.0](https://github.com/zip-rs/zip2/compare/v2.4.2...v2.5.0) - 2025-03-23

### <!-- 0 -->🚀 Features

- Add support for `time::PrimitiveDateTime` ([#322](https://github.com/zip-rs/zip2/pull/322))
- Add `jiff` integration ([#323](https://github.com/zip-rs/zip2/pull/323))

### <!-- 1 -->🐛 Bug Fixes

- improve error message for duplicated file ([#277](https://github.com/zip-rs/zip2/pull/277))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).