### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.0.0](https://github.com/zip-rs/zip2/compare/v2.6.1...v3.0.0) - 2025-05-12
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- When only zopfli is available, decompression of deflate should not be possible ([#348](https://github.com/zip-rs/zip2/pull/348))
+- Specify `flate2` dependency of the `deflate-flate2` feature. ([#345](https://github.com/zip-rs/zip2/pull/345))
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+
+- [**breaking**] Drop deprecated `deflate-miniz` feature flag
+
 ## [2.6.1](https://github.com/zip-rs/zip2/compare/v2.6.0...v2.6.1) - 2025-04-03
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "2.6.1"
+version = "3.0.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ Library to support the reading and writing of zip files.
 """
 edition = "2021"
 exclude = ["tests/**", "examples/**", ".github/**", "fuzz_read/**", "fuzz_write/**"]
-build = "src/build.rs"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -51,7 +50,6 @@ zopfli = { version = "0.8", optional = true }
 deflate64 = { version = "0.1.9", optional = true }
 lzma-rs = { version = "0.3", default-features = false, optional = true }
 xz2 = { version = "0.1.7", optional = true }
-proc-macro2 = { version = ">=1.0.60", optional = true } # Override transitive dep on 1.0.59 due to https://github.com/rust-lang/rust/issues/113152
 
 [target.'cfg(any(all(target_arch = "arm", target_pointer_width = "32"), target_arch = "mips", target_arch = "powerpc"))'.dependencies]
 crossbeam-utils = "0.8.21"
@@ -75,8 +73,6 @@ _deflate-any = []
 _all-features = [] # Detect when --all-features is used
 deflate = ["deflate-zopfli", "deflate-flate2"]
 deflate-flate2 = ["_deflate-any", "flate2/rust_backend"]
-# DEPRECATED: previously enabled `flate2/miniz_oxide` which is equivalent to `flate2/rust_backend`
-deflate-miniz = ["deflate", "deflate-flate2"]
 deflate-zlib = ["flate2/zlib", "deflate-flate2"]
 deflate-zlib-ng = ["flate2/zlib-ng", "deflate-flate2"]
 deflate-zopfli = ["zopfli", "_deflate-any"]

--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ The features available are:
 
 By default `aes-crypto`, `bzip2`, `deflate`, `deflate64`, `lzma`, `time` and `zstd` are enabled.
 
-The following feature flags are deprecated:
-
-* `deflate-miniz`: Use `flate2`'s default backend for compression. Currently the same as `deflate`.
-
 MSRV
 ----
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,7 +1,0 @@
-use std::env::var;
-
-fn main() {
-    if var("CARGO_FEATURE_DEFLATE_MINIZ").is_ok() && var("CARGO_FEATURE__ALL_FEATURES").is_err() {
-        println!("cargo:warning=Feature `deflate-miniz` is deprecated; replace it with `deflate`");
-    }
-}


### PR DESCRIPTION



## 🤖 New release

* `zip`: 2.6.1 -> 3.0.0 (⚠ API breaking changes)

### ⚠ `zip` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/feature_missing.ron

Failed in:
  feature proc-macro2 in the package's Cargo.toml
  feature deflate-miniz in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.0](https://github.com/zip-rs/zip2/compare/v2.6.1...v3.0.0) - 2025-05-12

### <!-- 1 -->🐛 Bug Fixes

- When only zopfli is available, decompression of deflate should not be possible ([#348](https://github.com/zip-rs/zip2/pull/348))
- Specify `flate2` dependency of the `deflate-flate2` feature. ([#345](https://github.com/zip-rs/zip2/pull/345))

### <!-- 7 -->⚙️ Miscellaneous Tasks

- [**breaking**] Drop deprecated `deflate-miniz` feature flag
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).