### PR TITLE
fix: When only zopfli is available, decompression of deflate should not be possible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         rustalias: [stable, nightly, msrv]
-        feature_flag: ["--all-features", "--no-default-features", ""]
+        feature_flag:
+        - "--all-features"
+        - "--no-default-features"
+        - "--no-default-features --features deflate-flate2"
+        - "--no-default-features --features deflate-zopfli"
+        - ""
         include:
         - rustalias: stable
           rust: stable
@@ -42,7 +47,12 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:
-        feature_flag: ["--all-features", "--no-default-features", ""]
+        feature_flag:
+        - "--all-features"
+        - "--no-default-features"
+        - "--no-default-features --features deflate-flate2"
+        - "--no-default-features --features deflate-zopfli"
+        - ""
     name: 'Miri ${{ matrix.feature_flag }}'
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ chrono = ["chrono/default"]
 _deflate-any = []
 _all-features = [] # Detect when --all-features is used
 deflate = ["deflate-zopfli", "deflate-flate2"]
-deflate-flate2 = ["flate2", "_deflate-any", "flate2/rust_backend"]
+deflate-flate2 = ["_deflate-any", "flate2/rust_backend"]
 # DEPRECATED: previously enabled `flate2/miniz_oxide` which is equivalent to `flate2/rust_backend`
 deflate-miniz = ["deflate", "deflate-flate2"]
 deflate-zlib = ["flate2/zlib", "deflate-flate2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ chrono = ["chrono/default"]
 _deflate-any = []
 _all-features = [] # Detect when --all-features is used
 deflate = ["deflate-zopfli", "deflate-flate2"]
-deflate-flate2 = ["_deflate-any", "flate2/rust_backend"]
+deflate-flate2 = ["flate2", "_deflate-any", "flate2/rust_backend"]
 # DEPRECATED: previously enabled `flate2/miniz_oxide` which is equivalent to `flate2/rust_backend`
 deflate-miniz = ["deflate", "deflate-flate2"]
 deflate-zlib = ["flate2/zlib", "deflate-flate2"]

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -193,7 +193,7 @@ pub const SUPPORTED_COMPRESSION_METHODS: &[CompressionMethod] = &[
 
 pub(crate) enum Decompressor<R: io::BufRead> {
     Stored(R),
-    #[cfg(feature = "_deflate-any")]
+    #[cfg(feature = "deflate-flate2")]
     Deflated(flate2::bufread::DeflateDecoder<R>),
     #[cfg(feature = "deflate64")]
     Deflate64(deflate64::Deflate64Decoder<R>),
@@ -211,7 +211,7 @@ impl<R: io::BufRead> io::Read for Decompressor<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
             Decompressor::Stored(r) => r.read(buf),
-            #[cfg(feature = "_deflate-any")]
+            #[cfg(feature = "deflate-flate2")]
             Decompressor::Deflated(r) => r.read(buf),
             #[cfg(feature = "deflate64")]
             Decompressor::Deflate64(r) => r.read(buf),
@@ -231,7 +231,7 @@ impl<R: io::BufRead> Decompressor<R> {
     pub fn new(reader: R, compression_method: CompressionMethod) -> crate::result::ZipResult<Self> {
         Ok(match compression_method {
             CompressionMethod::Stored => Decompressor::Stored(reader),
-            #[cfg(feature = "_deflate-any")]
+            #[cfg(feature = "deflate-flate2")]
             CompressionMethod::Deflated => {
                 Decompressor::Deflated(flate2::bufread::DeflateDecoder::new(reader))
             }
@@ -261,7 +261,7 @@ impl<R: io::BufRead> Decompressor<R> {
     pub fn into_inner(self) -> R {
         match self {
             Decompressor::Stored(r) => r,
-            #[cfg(feature = "_deflate-any")]
+            #[cfg(feature = "deflate-flate2")]
             Decompressor::Deflated(r) => r.into_inner(),
             #[cfg(feature = "deflate64")]
             Decompressor::Deflate64(r) => r.into_inner(),

--- a/src/read.rs
+++ b/src/read.rs
@@ -2146,7 +2146,7 @@ mod test {
         ZipArchive::new(Cursor::new(v)).expect_err("Invalid file");
     }
 
-    #[cfg(feature = "_deflate-any")]
+    #[cfg(feature = "deflate-flate2")]
     #[test]
     fn test_read_with_data_descriptor() {
         use std::io::Read;
@@ -2172,7 +2172,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "_deflate-any")]
+    #[cfg(feature = "deflate-flate2")]
     fn test_utf8_extra_field() {
         let mut v = Vec::new();
         v.extend_from_slice(include_bytes!("../tests/data/chinese.zip"));

--- a/src/write.rs
+++ b/src/write.rs
@@ -13,7 +13,7 @@ use crate::types::{
     ZipRawValues, MIN_VERSION,
 };
 use crate::write::ffi::S_IFLNK;
-#[cfg(any(feature = "_deflate-any", feature = "bzip2", feature = "zstd",))]
+#[cfg(feature = "deflate-zopfli")]
 use core::num::NonZeroU64;
 use crc32fast::Hasher;
 use indexmap::IndexMap;
@@ -754,6 +754,7 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     /// [`Self::finish()`].
     ///
     ///```
+    /// # #[cfg(all(feature = "deflate-zopfli", not(feature = "deflate-flate2")))] {
     /// # fn main() -> Result<(), zip::result::ZipError> {
     /// use std::io::{Cursor, prelude::*};
     /// use zip::{ZipArchive, ZipWriter, write::SimpleFileOptions};
@@ -769,6 +770,7 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     /// zip.by_name("a.txt")?.read_to_string(&mut s)?;
     /// assert_eq!(s, "hello\n");
     /// # Ok(())
+    /// # }
     /// # }
     ///```
     pub fn finish_into_readable(mut self) -> ZipResult<ZipArchive<A>> {
@@ -1191,6 +1193,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     /// calling [`Self::raw_copy_file()`] for each entry from the `source` archive in sequence.
     ///
     ///```
+    /// # #[cfg(all(feature = "deflate-zopfli", not(feature = "deflate-flate2")))] {
     /// # fn main() -> Result<(), zip::result::ZipError> {
     /// use std::io::{Cursor, prelude::*};
     /// use zip::{ZipArchive, ZipWriter, write::SimpleFileOptions};
@@ -1208,6 +1211,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     /// let src2 = ZipArchive::new(zip.finish()?)?;
     ///
     /// let buf = Cursor::new(Vec::new());
+    ///
     /// let mut zip = ZipWriter::new(buf);
     /// zip.merge_archive(src)?;
     /// zip.merge_archive(src2)?;
@@ -1220,6 +1224,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     /// result.by_name("b.txt")?.read_to_string(&mut s)?;
     /// assert_eq!(s, "hey\n");
     /// # Ok(())
+    /// # }
     /// # }
     ///```
     pub fn merge_archive<R>(&mut self, mut source: ZipArchive<R>) -> ZipResult<()>
@@ -1660,14 +1665,11 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                 }
                 #[cfg(feature = "_deflate-any")]
                 CompressionMethod::Deflated => {
-                    let default = if cfg!(all(
-                        feature = "deflate-zopfli",
-                        not(feature = "deflate-flate2")
-                    )) {
-                        24
-                    } else {
-                        Compression::default().level() as i64
-                    };
+                    #[cfg(feature = "deflate-flate2")]
+                    let default = Compression::default().level() as i64;
+
+                    #[cfg(all(feature = "deflate-zopfli", not(feature = "deflate-flate2")))]
+                    let default = 24;
 
                     let level = clamp_opt(
                         compression_level.unwrap_or(default),
@@ -1677,12 +1679,11 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                         as u32;
 
                     #[cfg(feature = "deflate-zopfli")]
-                    {
-                        let best_non_zopfli = Compression::best().level();
-                        if level > best_non_zopfli {
+                    macro_rules! deflate_zopfli_and_return {
+                        ($bare:expr, $best_non_zopfli:expr) => {
                             let options = Options {
                                 iteration_count: NonZeroU64::try_from(
-                                    (level - best_non_zopfli) as u64,
+                                    (level - $best_non_zopfli) as u64,
                                 )
                                 .unwrap(),
                                 ..Default::default()
@@ -1702,7 +1703,21 @@ impl<W: Write + Seek> GenericZipWriter<W> {
                                     zopfli::DeflateEncoder::new(options, Default::default(), bare),
                                 ),
                             }));
+                        };
+                    }
+
+                    #[cfg(all(feature = "deflate-zopfli", feature = "deflate-flate2"))]
+                    {
+                        let best_non_zopfli = Compression::best().level();
+                        if level > best_non_zopfli {
+                            deflate_zopfli_and_return!(bare, best_non_zopfli);
                         }
+                    }
+
+                    #[cfg(all(feature = "deflate-zopfli", not(feature = "deflate-flate2")))]
+                    {
+                        let best_non_zopfli = 9;
+                        deflate_zopfli_and_return!(bare, best_non_zopfli);
                     }
 
                     #[cfg(feature = "deflate-flate2")]
@@ -1838,18 +1853,15 @@ impl<W: Write + Seek> GenericZipWriter<W> {
 
 #[cfg(feature = "_deflate-any")]
 fn deflate_compression_level_range() -> std::ops::RangeInclusive<i64> {
-    let min = if cfg!(feature = "deflate-flate2") {
-        Compression::fast().level() as i64
-    } else {
-        Compression::best().level() as i64 + 1
-    };
+    #[cfg(feature = "deflate-flate2")]
+    let min = Compression::fast().level() as i64;
+    #[cfg(all(feature = "deflate-zopfli", not(feature = "deflate-flate2")))]
+    let min = 1;
 
-    let max = Compression::best().level() as i64
-        + if cfg!(feature = "deflate-zopfli") {
-            u8::MAX as i64
-        } else {
-            0
-        };
+    #[cfg(feature = "deflate-zopfli")]
+    let max = 264;
+    #[cfg(all(feature = "deflate-flate2", not(feature = "deflate-zopfli")))]
+    let max = Compression::best().level() as i64;
 
     min..=max
 }
@@ -2001,7 +2013,9 @@ mod test {
     use crate::zipcrypto::ZipCryptoKeys;
     use crate::CompressionMethod::Stored;
     use crate::ZipArchive;
-    use std::io::{Cursor, Read, Write};
+    #[cfg(feature = "deflate-flate2")]
+    use std::io::Read;
+    use std::io::{Cursor, Write};
     use std::marker::PhantomData;
     use std::path::PathBuf;
 
@@ -2156,14 +2170,18 @@ mod test {
         assert_eq!(result.get_ref(), &v);
     }
 
+    #[cfg(feature = "deflate-flate2")]
     const RT_TEST_TEXT: &str = "And I can't stop thinking about the moments that I lost to you\
                             And I can't stop thinking of things I used to do\
                             And I can't stop making bad decisions\
                             And I can't stop eating stuff you make me chew\
                             I put on a smile like you wanna see\
                             Another day goes by that I long to be like you";
+    #[cfg(feature = "deflate-flate2")]
     const RT_TEST_FILENAME: &str = "subfolder/sub-subfolder/can't_stop.txt";
+    #[cfg(feature = "deflate-flate2")]
     const SECOND_FILENAME: &str = "different_name.xyz";
+    #[cfg(feature = "deflate-flate2")]
     const THIRD_FILENAME: &str = "third_name.xyz";
 
     #[test]
@@ -2219,6 +2237,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "deflate-flate2")]
     fn test_shallow_copy() {
         let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         let options = FileOptions {
@@ -2269,6 +2288,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "deflate-flate2")]
     fn test_deep_copy() {
         let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         let options = FileOptions {
@@ -2440,6 +2460,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "deflate-flate2")]
     fn remove_shallow_copy_keeps_original() -> ZipResult<()> {
         let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -13,9 +13,20 @@ use zip::{CompressionMethod, ZipWriter, SUPPORTED_COMPRESSION_METHODS};
 #[test]
 fn end_to_end() {
     for &method in SUPPORTED_COMPRESSION_METHODS {
+        if method == CompressionMethod::DEFLATE
+            && cfg!(all(
+                feature = "deflate-zopfli",
+                not(feature = "deflate-flate2")
+            ))
+        {
+            // We do not support DEFLATE decompression without the `flate2` feature.
+            continue;
+        }
+
         if method == CompressionMethod::DEFLATE64 {
             continue;
         }
+
         let file = &mut Cursor::new(Vec::new());
 
         println!("Writing file with {method} compression");
@@ -32,9 +43,20 @@ fn end_to_end() {
 #[test]
 fn copy() {
     for &method in SUPPORTED_COMPRESSION_METHODS {
+        if method == CompressionMethod::DEFLATE
+            && cfg!(all(
+                feature = "deflate-zopfli",
+                not(feature = "deflate-flate2")
+            ))
+        {
+            // We do not support DEFLATE decompression without the `flate2` feature.
+            continue;
+        }
+
         if method == CompressionMethod::DEFLATE64 {
             continue;
         }
+
         let src_file = &mut Cursor::new(Vec::new());
         write_test_archive(src_file, method, false);
 
@@ -74,9 +96,20 @@ fn copy() {
 #[test]
 fn append() {
     for &method in SUPPORTED_COMPRESSION_METHODS {
+        if method == CompressionMethod::DEFLATE
+            && cfg!(all(
+                feature = "deflate-zopfli",
+                not(feature = "deflate-flate2")
+            ))
+        {
+            // We do not support DEFLATE decompression without the `flate2` feature.
+            continue;
+        }
+
         if method == CompressionMethod::DEFLATE64 {
             continue;
         }
+
         for shallow_copy in &[false, true] {
             println!("Writing file with {method} compression, shallow_copy {shallow_copy}");
             let mut file = &mut Cursor::new(Vec::new());

--- a/tests/extract_symlink.rs
+++ b/tests/extract_symlink.rs
@@ -1,5 +1,5 @@
 #[test]
-#[cfg(all(unix, feature = "_deflate-any"))]
+#[cfg(all(unix, feature = "deflate-flate2"))]
 fn extract_should_respect_links() {
     use std::{fs, io, path::PathBuf, str::FromStr};
     use tempfile::TempDir;

--- a/tests/repro_old423.rs
+++ b/tests/repro_old423.rs
@@ -1,4 +1,4 @@
-#[cfg(all(unix, feature = "_deflate-any"))]
+#[cfg(all(unix, feature = "deflate-flate2"))]
 #[test]
 fn repro_old423() -> zip::result::ZipResult<()> {
     use std::io;

--- a/tests/root_dir.rs
+++ b/tests/root_dir.rs
@@ -1,6 +1,12 @@
+#[cfg(feature = "deflate-flate2")]
 use std::fs;
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+#[cfg(feature = "deflate-flate2")]
+use std::io::Read;
+use std::io::Write;
+#[cfg(feature = "deflate-flate2")]
+use std::path::Path;
+use std::path::PathBuf;
+#[cfg(feature = "deflate-flate2")]
 use tempfile::TempDir;
 use zip::read::root_dir_common_filter;
 use zip::write::SimpleFileOptions;
@@ -153,6 +159,7 @@ fn test_root_dir_with_multiple_root_dirs() {
 }
 
 #[test]
+#[cfg(feature = "deflate-flate2")]
 fn test_extract_without_root_dir() {
     let zip_data = create_zip_with_root_dir();
     let mut archive = ZipArchive::new(std::io::Cursor::new(zip_data)).unwrap();
@@ -180,6 +187,7 @@ fn test_extract_without_root_dir() {
 }
 
 #[test]
+#[cfg(feature = "deflate-flate2")]
 fn test_extract_without_root_dir_but_no_root_found() {
     let zip_data = create_zip_without_root_dir();
     let mut archive = ZipArchive::new(std::io::Cursor::new(zip_data)).unwrap();
@@ -197,6 +205,7 @@ fn test_extract_without_root_dir_but_no_root_found() {
 }
 
 #[test]
+#[cfg(feature = "deflate-flate2")]
 fn test_extract_without_root_dir_with_ds_store() {
     let zip_data = create_zip_with_root_dir_and_ds_store();
     let mut archive = ZipArchive::new(std::io::Cursor::new(zip_data)).unwrap();
@@ -219,6 +228,7 @@ fn test_extract_without_root_dir_with_ds_store() {
 }
 
 #[test]
+#[cfg(feature = "deflate-flate2")]
 fn test_custom_root_dir_filter() {
     let zip_data = create_zip_with_root_dir();
     let mut archive = ZipArchive::new(std::io::Cursor::new(zip_data)).unwrap();

--- a/tests/zip_crypto.rs
+++ b/tests/zip_crypto.rs
@@ -36,6 +36,7 @@ use std::io::Cursor;
 use zip::result::ZipError;
 
 #[test]
+#[cfg(feature = "deflate-flate2")]
 fn encrypting_file() {
     use std::io::{Read, Write};
     use zip::unstable::write::FileOptionsExt;


### PR DESCRIPTION
Fixes #347.

Zopfli is a **compression only** algorithm. This means that it cannot be used to **decompress** DEFLATE streams. However, the code currently implies this, and tries to build flate2-related code paths because zopfli sets `_deflate_any`.

However, unsetting `_deflate_any` is not enough: zopfli can still compress DEFLATE streams even if it can't decompress them.

So to make sure everything is still OK, allow decompression of DEFLATE only when `flate2` is active, but allow compression both when only `zopfli` is active (in this case, shift the compression level by 9 so the same functionality takes place as when flate2 is enabled), and when both `zopfli` and `flate2` are active (in this case, use `flate2` when compression level is less than 9, and `zopfli` when compression level is higher than 9, as the original intent).

The `if cfg!(...)` paradigm only works if both conditional blocks can compile regardless of the config options, so instead we must use `#[cfg[...]]` to compile out the parts that can't compile when `flate2` is not available.

As for the compression level ranges:
- only zopfli: 1-254
- only flate2: fast-best (1-9)
- both zopfli and flate2: fast-254 (1-254)
  - flate2 takes place between 1-9
  - zopfli takes place between 10-254

Tests have been modified: some tests require writing DEFLATE zip files as well. Those tests are disabled when DEFLATE can't be compressed, only uncompressed. Two doctests require writing DEFLATE zip files as well, so these doctests are now protected with the config guard.

The CI workflow has also been extended to build two more variants of the crate: one with only `flate2` enabled and one with only `zopfli` enabled.

The CI/CD pipeline builds fine: https://github.com/darktohka/zip2/actions/runs/14960898954

To test this pull request:
1. git clone `https://github.com/darktohka/zip-flate2-zopfli-feature-repro`
2. cd ..
3. cd [zopfli-only-success-fixed](https://github.com/darktohka/zip-flate2-zopfli-feature-repro/tree/master/zopfli-only-success-fixed)
4. `cargo build` ==> builds fine