### PR TITLE
feat!: zip 3.0: Adjust flate2-related features for 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,14 +25,14 @@ jobs:
         feature_flag:
         - "--all-features"
         - "--no-default-features"
-        - "--no-default-features --features deflate-flate2"
+        - "--no-default-features --features deflate-flate2-zlib-rs"
         - "--no-default-features --features deflate-zopfli"
         - ""
         include:
         - rustalias: stable
           rust: stable
         - rustalias: msrv
-          rust: '1.73'
+          rust: '1.75'
         - rustalias: nightly
           rust: nightly
     name: 'Build and test ${{ matrix.feature_flag }}: ${{ matrix.os }}, ${{ matrix.rustalias }}'
@@ -50,7 +50,7 @@ jobs:
         feature_flag:
         - "--all-features"
         - "--no-default-features"
-        - "--no-default-features --features deflate-flate2"
+        - "--no-default-features --features deflate-flate2-zlib-rs"
         - "--no-default-features --features deflate-zopfli"
         - ""
     name: 'Miri ${{ matrix.feature_flag }}'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/zip-rs/zip2.git"
 keywords = ["zip", "archive", "compression"]
 # Any change to rust-version must be reflected also in `README.md` and `.github/workflows/ci.yaml`.
 # The MSRV policy is documented in `README.md`.
-rust-version = "1.73.0"
+rust-version = "1.75.0"
 description = """
 Library to support the reading and writing of zip files.
 """
@@ -32,7 +32,7 @@ bzip2 = { version = "0.5.0", optional = true }
 chrono = { version = "0.4", optional = true }
 constant_time_eq = { version = "0.3", optional = true }
 crc32fast = "1.4"
-flate2 = { version = "1.0", default-features = false, optional = true }
+flate2 = { version = "1.1.1", default-features = false, optional = true }
 getrandom = { version = "0.3.1", features = ["wasm_js", "std"], optional = true}
 hmac = { version = "0.12", optional = true, features = ["reset"] }
 indexmap = "2"
@@ -71,10 +71,13 @@ aes-crypto = ["aes", "constant_time_eq", "hmac", "pbkdf2", "sha1", "getrandom", 
 chrono = ["chrono/default"]
 _deflate-any = []
 _all-features = [] # Detect when --all-features is used
-deflate = ["deflate-zopfli", "deflate-flate2", "flate2/rust_backend"]
-deflate-flate2 = ["_deflate-any"]
-deflate-zlib = ["flate2/zlib", "deflate-flate2"]
-deflate-zlib-ng = ["flate2/zlib-ng", "deflate-flate2"]
+deflate = ["deflate-zopfli", "deflate-flate2-zlib-rs"]
+# Pull in flate2, but don't choose a backend; useful if you want to choose your own flate2 backend
+deflate-flate2 = ["_deflate-any", "dep:flate2"]
+# Pull in flate2 and the fast zlib-rs backend; this is what most users will want
+deflate-flate2-zlib-rs = ["deflate-flate2", "flate2/zlib-rs"]
+# Pull in flate2 and the zlib backend; only use this if you need a dynamically linked system zlib
+deflate-flate2-zlib = ["deflate-flate2", "flate2/zlib"]
 deflate-zopfli = ["zopfli", "_deflate-any"]
 jiff-02 = ["dep:jiff"]
 nt-time = ["dep:nt-time"]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ By default `aes-crypto`, `bzip2`, `deflate`, `deflate64`, `lzma`, `time` and `zs
 MSRV
 ----
 
-Our current Minimum Supported Rust Version is **1.73**. When adding features,
+Our current Minimum Supported Rust Version is **1.75**. When adding features,
 we will follow these guidelines:
 
 - We will always support a minor Rust version that has been stable for at least 6 months.

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -25,8 +25,6 @@ struct Args {
 enum CompressionMethod {
     Stored,
     Deflated,
-    DeflatedZlib,
-    DeflatedZlibNg,
     Bzip2,
     Zstd,
 }
@@ -48,24 +46,6 @@ fn real_main() -> i32 {
                 return 1;
             }
             #[cfg(feature = "deflate-flate2")]
-            zip::CompressionMethod::Deflated
-        }
-        CompressionMethod::DeflatedZlib => {
-            #[cfg(not(feature = "deflate-zlib"))]
-            {
-                println!("The `deflate-zlib` feature is not enabled");
-                return 1;
-            }
-            #[cfg(feature = "deflate-zlib")]
-            zip::CompressionMethod::Deflated
-        }
-        CompressionMethod::DeflatedZlibNg => {
-            #[cfg(not(feature = "deflate-zlib-ng"))]
-            {
-                println!("The `deflate-zlib-ng` feature is not enabled");
-                return 1;
-            }
-            #[cfg(feature = "deflate-zlib-ng")]
             zip::CompressionMethod::Deflated
         }
         CompressionMethod::Bzip2 => {


### PR DESCRIPTION
Move `deflate-zlib` to `deflate-flate2-zlib` to make it clear it's a
flate2 backend, and add `deflate-flate2-zlib-rs` to use the zlib-rs
backend. Make the latter the default.

Bump the required flate2 version to one that works with zlib-rs 0.5.0,
which removes all compatibility considerations by no longer exporting
any C symbols that would conflict with another zlib.

Remove `deflate-zlib-ng`, largely superseded by
`deflate-flate2-zlib-rs`.

Remove no-op backend-specific code from an example.

Add documentation for the flate2-related feature flags.
