### PR TITLE
fix: Allow extraction of Zip64 archives where EOCD64's field "Version needed to extract" is higher than "Version made by"

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -496,9 +496,6 @@ impl<'a> TryFrom<&'a CentralDirectoryEndInfo> for CentralDirectoryInfo {
                 Some(DataAndPosition { data: eocd64, .. }) => {
                     if eocd64.number_of_files_on_this_disk > eocd64.number_of_files {
                         return Err(invalid!("ZIP64 footer indicates more files on this disk than in the whole archive"));
-                    } else if eocd64.version_needed_to_extract > eocd64.version_made_by {
-                        return Err(invalid!("ZIP64 footer indicates a new version is needed to extract this archive than the \
-                                                         version that wrote it"));
                     }
                     (
                         eocd64.central_directory_offset,


### PR DESCRIPTION
As described by #251 , there is currently a check in `read.rs` that invalidates Zip64 archives where the field "Version needed to extract" contained in the EOCD64 header is higher than the field "Version made by", making `ZipArchive::new()` return `InvalidArchive("Could not find EOCD")` for these types of files.

Although the current behavior may be considered correct, there is currently no other tool as far as I am aware that returns an error or fails to parse these files completely. `zip -T` and `unzip -t`, for example, validate these types of archives with no errors.

This issue is somewhat prevalent as it disallows reading Zip64 archives downloaded from GitHub directly.

Even if this pull request is not accepted, I would still suggest improving the currently returning error message, as the more correct `"ZIP64 footer indicates a new version is needed to extract this archive than the version that wrote it"` is lost during the second run of the `ZipArchive::get_metadata` loop:

```rust
// ZipArchive::get_metadata
loop {
    // Find the EOCD and possibly EOCD64 entries and determine the archive offset.
    // >> This returns the correct error during the first loop, however the error is
    // >> subsequently ignored as the function tries to search for another EOCD instance.
    let cde = spec::find_central_directory(
        reader,
        config.archive_offset,
        end_exclusive,
        file_len,
    )?;

    // Turn EOCD into internal representation.
    let Ok(shared) = CentralDirectoryInfo::try_from(&cde)
        .and_then(|info| Self::read_central_header(info, config, reader))
    else {
        // The next EOCD candidate should start before the current one.
        end_exclusive = cde.eocd.position;
        continue;
    };

    return Ok(shared.build(
        cde.eocd.data.zip_file_comment,
        cde.eocd64.map(|v| v.data.extensible_data_sector),
    ));
}
```

**Changes**

- Removed `CentralDirectoryEndInfo` to `CentralDirectoryInfo` `TryFrom` implementation's `eocd64.version_needed_to_extract > eocd64.version_made_by` validation check.

Related issues:
#251 