### PR TITLE
deps: Upgrade to bzip2 0.6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         - rustalias: stable
           rust: stable
         - rustalias: msrv
-          rust: '1.75'
+          rust: '1.82'
         - rustalias: nightly
           rust: nightly
     name: 'Build and test ${{ matrix.feature_flag }}: ${{ matrix.os }}, ${{ matrix.rustalias }}'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ time = { version = "0.3.37", default-features = false }
 
 [dependencies]
 aes = { version = "0.8", optional = true }
-bzip2 = { version = "0.5.0", optional = true }
+bzip2 = { version = "0.6.0", optional = true }
 chrono = { version = "0.4", optional = true }
 constant_time_eq = { version = "0.3.1", optional = true }
 crc32fast = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/zip-rs/zip2.git"
 keywords = ["zip", "archive", "compression"]
 # Any change to rust-version must be reflected also in `README.md` and `.github/workflows/ci.yaml`.
 # The MSRV policy is documented in `README.md`.
-rust-version = "1.75.0"
+rust-version = "1.82.0"
 description = """
 Library to support the reading and writing of zip files.
 """

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ By default `aes-crypto`, `bzip2`, `deflate`, `deflate64`, `lzma`, `time` and `zs
 MSRV
 ----
 
-Our current Minimum Supported Rust Version is **1.75**. When adding features,
+Our current Minimum Supported Rust Version is **1.82**. When adding features,
 we will follow these guidelines:
 
 - We will always support a minor Rust version that has been stable for at least 6 months.

--- a/examples/write-large-file.rs
+++ b/examples/write-large-file.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .large_file(true)
             .unix_permissions(0o755);
         zip.start_file("huge-file-of-zeroes", options)?;
-        let content: Vec<_> = std::iter::repeat(0_u8).take(65 * 1024).collect();
+        let content: Vec<_> = std::iter::repeat_n(0_u8, 65 * 1024).collect();
         let mut bytes_written = 0_u64;
         while bytes_written < u32::MAX as u64 {
             zip.write_all(&content)?;


### PR DESCRIPTION
Upgrade to bzip2 0.6.0, which has the benefit of being in pure Rust now.
