### PR TITLE
feat: Add StreamWriter::into_inner()

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -2040,6 +2040,11 @@ impl<W: Write> StreamWriter<W> {
             bytes_written: 0,
         }
     }
+
+    /// Consumes this wrapper, returning the underlying writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
 }
 
 impl<W: Write> Write for StreamWriter<W> {


### PR DESCRIPTION
This way, it's possible to retrieve the original writer after writing a file via `ZipWriter::new_stream()`.
