### PR TITLE
fix: Include magic signature when writing data descriptors

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -49,6 +49,7 @@ impl Magic {
     pub const CENTRAL_DIRECTORY_END_SIGNATURE: Self = Self::literal(0x06054b50);
     pub const ZIP64_CENTRAL_DIRECTORY_END_SIGNATURE: Self = Self::literal(0x06064b50);
     pub const ZIP64_CENTRAL_DIRECTORY_END_LOCATOR_SIGNATURE: Self = Self::literal(0x07064b50);
+    pub const DATA_DESCRIPTOR_SIGNATURE: Self = Self::literal(0x08074b50);
 }
 
 /// Similar to [`Magic`], but used for extra field tags as per section 4.5.3 of APPNOTE.TXT.

--- a/src/types.rs
+++ b/src/types.rs
@@ -952,6 +952,28 @@ impl ZipFileData {
             self.header_start,
         )
     }
+
+    pub(crate) fn data_descriptor_block(&self) -> Option<ZipDataDescriptorBlock> {
+        if self.large_file {
+            return None;
+        }
+
+        Some(ZipDataDescriptorBlock {
+            magic: ZipDataDescriptorBlock::MAGIC,
+            crc32: self.crc32,
+            compressed_size: self.compressed_size as u32,
+            uncompressed_size: self.uncompressed_size as u32,
+        })
+    }
+
+    pub(crate) fn zip64_data_descriptor_block(&self) -> Zip64DataDescriptorBlock {
+        Zip64DataDescriptorBlock {
+            magic: Zip64DataDescriptorBlock::MAGIC,
+            crc32: self.crc32,
+            compressed_size: self.compressed_size,
+            uncompressed_size: self.uncompressed_size,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -1137,6 +1159,64 @@ impl Zip64ExtraFieldBlock {
 
         ret.into_boxed_slice()
     }
+}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(packed, C)]
+pub(crate) struct ZipDataDescriptorBlock {
+    magic: spec::Magic,
+    pub crc32: u32,
+    pub compressed_size: u32,
+    pub uncompressed_size: u32,
+}
+
+unsafe impl Pod for ZipDataDescriptorBlock {}
+
+impl FixedSizeBlock for ZipDataDescriptorBlock {
+    const MAGIC: spec::Magic = spec::Magic::DATA_DESCRIPTOR_SIGNATURE;
+
+    #[inline(always)]
+    fn magic(self) -> spec::Magic {
+        self.magic
+    }
+
+    const WRONG_MAGIC_ERROR: ZipError = invalid!("Invalid data descriptor header");
+
+    to_and_from_le![
+        (magic, spec::Magic),
+        (crc32, u32),
+        (compressed_size, u32),
+        (uncompressed_size, u32),
+    ];
+}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(packed, C)]
+pub(crate) struct Zip64DataDescriptorBlock {
+    magic: spec::Magic,
+    pub crc32: u32,
+    pub compressed_size: u64,
+    pub uncompressed_size: u64,
+}
+
+unsafe impl Pod for Zip64DataDescriptorBlock {}
+
+impl FixedSizeBlock for Zip64DataDescriptorBlock {
+    const MAGIC: spec::Magic = spec::Magic::DATA_DESCRIPTOR_SIGNATURE;
+
+    #[inline(always)]
+    fn magic(self) -> spec::Magic {
+        self.magic
+    }
+
+    const WRONG_MAGIC_ERROR: ZipError = invalid!("Invalid zip64 data descriptor header");
+
+    to_and_from_le![
+        (magic, spec::Magic),
+        (crc32, u32),
+        (compressed_size, u64),
+        (uncompressed_size, u64),
+    ];
 }
 
 /// The encryption specification used to encrypt a file with AES.


### PR DESCRIPTION
Per section 4.3.9.4 of `APPNOTE`, writers should include the magic signature for data descriptors. Despite it being optional, some parsers require it, so this should help increase compatibility.

This commit also switches from performing raw writes for data descriptors to using the `FixedSizeBlock` API.

---

```
      4.3.9.4 When writing ZIP files, implementors SHOULD include the
      signature value marking the data descriptor record.  When
      the signature is used, the fields currently defined for
      the data descriptor record will immediately follow the
      signature.
```