### PR TITLE
Potential fix for code scanning alert no. 213: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ env:
   RUSTFLAGS: -Dwarnings
   MACOSX_DEPLOYMENT_TARGET: "14.5"
 
+permissions:
+  contents: read
 jobs:
   build_and_test:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name


### PR DESCRIPTION
Potential fix for [https://github.com/zip-rs/zip2/security/code-scanning/213](https://github.com/zip-rs/zip2/security/code-scanning/213)

To fix the problem, you should specify a `permissions` block at the workflow root level in `.github/workflows/ci.yaml`, before the `jobs:` key. This will ensure that all jobs default to the least privilege required (`contents: read`), unless they specify broader permissions explicitly. This change does not alter any existing workflow functionality, and only restricts the default scope of the `GITHUB_TOKEN` used by the workflow. The edit consists of inserting a block:

```yaml
permissions:
  contents: read
```
between the global environment block (after line 17) and the `jobs:` key (before line 18).

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
