### PR TITLE
Potential fix for code scanning alert no. 205: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/zip-rs/zip2/security/code-scanning/205](https://github.com/zip-rs/zip2/security/code-scanning/205)

To fix this issue, you should add an explicit `permissions` block at the workflow root of `.github/workflows/ci.yaml`. This block should restrict GITHUB_TOKEN access, preferably to the minimal `contents: read`, unless some jobs need additional privileges (e.g., `pull-requests: write`). In this case, since no jobs appear to require write privileges, setting `permissions: contents: read` at the top level suffices and applies to all jobs. The change should be added directly below the workflow name (line 1). No additional imports, definitions, or code changes are needed, just the addition of this YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
