### PR TITLE
chore: release v9.0.0-pre2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0-pre2.1](https://github.com/zip-rs/zip2/compare/v9.0.0-pre2...v9.0.0-pre2.1) - 2026-06-05
+
+### <!-- 0 -->🚀 Features
+
+- add method to README ([#857](https://github.com/zip-rs/zip2/pull/857))
+
+### <!-- 2 -->🚜 Refactor
+
+- change zip64 parsing ([#834](https://github.com/zip-rs/zip2/pull/834))
+
 ## [9.0.0-pre2](https://github.com/zip-rs/zip2/compare/v9.0.0-pre1...v9.0.0-pre1.1) - 2026-05-11
 
 ### <!-- 2 -->🚜 Refactor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "9.0.0-pre2"
+version = "9.0.0-pre2.1"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION



## 🤖 New release

* `zip`: 9.0.0-pre2 -> 9.0.0-pre2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [9.0.0-pre2.1](https://github.com/zip-rs/zip2/compare/v9.0.0-pre2...v9.0.0-pre2.1) - 2026-06-05

### <!-- 0 -->🚀 Features

- add method to README ([#857](https://github.com/zip-rs/zip2/pull/857))

### <!-- 2 -->🚜 Refactor

- change zip64 parsing ([#834](https://github.com/zip-rs/zip2/pull/834))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).