### PR TITLE
chore: release v9.0.0-pre3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.0.0-pre2.1](https://github.com/zip-rs/zip2/compare/v9.0.0-pre2...v9.0.0-pre2.1) - 2026-07-10
+## [9.0.0-pre3](https://github.com/zip-rs/zip2/compare/v9.0.0-pre2...v9.0.0-pre3) - 2026-07-10
 
 ### <!-- 0 -->🚀 Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0-pre2.1](https://github.com/zip-rs/zip2/compare/v9.0.0-pre2...v9.0.0-pre2.1) - 2026-07-10
+
+### <!-- 0 -->🚀 Features
+
+- add example for memory allocation ([#881](https://github.com/zip-rs/zip2/pull/881))
+- add method to README ([#857](https://github.com/zip-rs/zip2/pull/857))
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- zip64 creation of exactly 4GB without large file should crash ([#839](https://github.com/zip-rs/zip2/pull/839))
+- remove seek call and inline ([#858](https://github.com/zip-rs/zip2/pull/858))
+- change directory attributes detection and set `external attributes` ([#851](https://github.com/zip-rs/zip2/pull/851))
+- ignore zip info extra field on failure ([#868](https://github.com/zip-rs/zip2/pull/868))
+
+### <!-- 2 -->🚜 Refactor
+
+- change extra_data to extra_fields ([#833](https://github.com/zip-rs/zip2/pull/833))
+- change zip64 parsing ([#834](https://github.com/zip-rs/zip2/pull/834))
+
 ## [9.0.0-pre2](https://github.com/zip-rs/zip2/compare/v9.0.0-pre1...v9.0.0-pre1.1) - 2026-05-11
 
 ### <!-- 2 -->🚜 Refactor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "9.0.0-pre2.1"
+version = "9.0.0-pre3"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "9.0.0-pre2"
+version = "9.0.0-pre2.1"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION



## 🤖 New release

* `zip`: 9.0.0-pre2 -> 9.0.0-pre2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [9.0.0-pre2.1](https://github.com/zip-rs/zip2/compare/v9.0.0-pre2...v9.0.0-pre2.1) - 2026-07-10

### <!-- 0 -->🚀 Features

- add example for memory allocation ([#881](https://github.com/zip-rs/zip2/pull/881))
- add method to README ([#857](https://github.com/zip-rs/zip2/pull/857))

### <!-- 1 -->🐛 Bug Fixes

- zip64 creation of exactly 4GB without large file should crash ([#839](https://github.com/zip-rs/zip2/pull/839))
- remove seek call and inline ([#858](https://github.com/zip-rs/zip2/pull/858))
- change directory attributes detection and set `external attributes` ([#851](https://github.com/zip-rs/zip2/pull/851))
- ignore zip info extra field on failure ([#868](https://github.com/zip-rs/zip2/pull/868))

### <!-- 2 -->🚜 Refactor

- change extra_data to extra_fields ([#833](https://github.com/zip-rs/zip2/pull/833))
- change zip64 parsing ([#834](https://github.com/zip-rs/zip2/pull/834))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).