### PR TITLE
feat: Rewrite zip64 extra

### DIFF
--- a/src/extra_fields/extra_field.rs
+++ b/src/extra_fields/extra_field.rs
@@ -8,13 +8,13 @@ use crate::extra_fields::Ntfs;
 use crate::extra_fields::UnicodeExtraField;
 use crate::extra_fields::UsedExtraField;
 use crate::extra_fields::Zip64ExtendedInformation;
+use crate::extra_fields::zip64_extended_information::Zip64Sizes;
 use crate::format::flags::ZipFlags;
 use crate::result::ZipResult;
 use crate::result::invalid;
 use crate::spec::ZipEntryBlock;
 use crate::types::ZipFileData;
 use crate::unstable::LittleEndianReadExt;
-use core::mem;
 use std::io::ErrorKind;
 use std::io::{Cursor, Read, Write};
 
@@ -31,14 +31,7 @@ pub enum ExtraField {
     /// AeX Encryption
     AeXEncryption(AexEncryption),
     /// Zip64 Information
-    Zip64ExtendedInformation {
-        /// uncompressed size
-        uncompressed_size: Option<u64>,
-        /// compressed size
-        compressed_size: Option<u64>,
-        /// header start
-        header_start: Option<u64>,
-    },
+    Zip64ExtendedInformation(Zip64ExtendedInformation),
     /// Unicode Comment
     UnicodeComment(UnicodeExtraField),
     /// UnicodePath
@@ -131,11 +124,13 @@ impl ExtraField {
                     file.get_compressed_size(),
                     file.get_header_start(),
                 )?;
-                ExtraField::Zip64ExtendedInformation {
-                    uncompressed_size: Some(new_uncomp),
-                    compressed_size: Some(new_comp),
+                ExtraField::Zip64ExtendedInformation(Zip64ExtendedInformation {
+                    sizes: Some(Zip64Sizes {
+                        uncompressed_size: new_uncomp,
+                        compressed_size: new_comp,
+                    }),
                     header_start: Some(new_head),
-                }
+                })
             }
             Ok(UsedExtraField::Ntfs) => {
                 // NTFS extra field
@@ -183,22 +178,8 @@ impl ExtraField {
     pub(crate) fn size(&self, is_local_header: bool) -> usize {
         match self {
             // Zip64 extended information extra field
-            ExtraField::Zip64ExtendedInformation {
-                uncompressed_size,
-                compressed_size,
-                header_start,
-            } => {
-                let mut size = mem::size_of::<UsedExtraField>() + mem::size_of::<u16>();
-                if uncompressed_size.is_some() {
-                    size += mem::size_of::<u64>();
-                }
-                if compressed_size.is_some() {
-                    size += mem::size_of::<u64>();
-                }
-                if !is_local_header && header_start.is_some() {
-                    size += mem::size_of::<u64>();
-                }
-                size
+            ExtraField::Zip64ExtendedInformation(zip64_extra) => {
+                zip64_extra.full_size(is_local_header)
             }
             ExtraField::Ntfs(_ntfs) => {
                 // NTFS extra field
@@ -221,26 +202,8 @@ impl ExtraField {
     pub(crate) fn write<W: Write>(&self, writer: &mut W, is_local_header: bool) -> ZipResult<()> {
         match self {
             // Zip64 extended information extra field
-            ExtraField::Zip64ExtendedInformation {
-                compressed_size,
-                uncompressed_size,
-                header_start,
-            } => {
-                let magic = UsedExtraField::Zip64ExtendedInfo.as_u16();
-                writer.write_all(&magic.to_le_bytes())?;
-                let size = self.size(is_local_header);
-                let size = size - mem::size_of::<u16>() - mem::size_of::<u16>();
-                let size = size as u16;
-                writer.write_all(&size.to_le_bytes())?;
-                if let Some(uncomp_size) = uncompressed_size {
-                    writer.write_all(&uncomp_size.to_le_bytes())?;
-                }
-                if let Some(comp_size) = compressed_size {
-                    writer.write_all(&comp_size.to_le_bytes())?;
-                }
-                if !is_local_header && let Some(head_start) = header_start {
-                    writer.write_all(&head_start.to_le_bytes())?;
-                }
+            ExtraField::Zip64ExtendedInformation(zip64_extra) => {
+                zip64_extra.write(writer, is_local_header)?;
             }
             ExtraField::AeXEncryption(aex) => {
                 aex.write(writer)?;
@@ -274,19 +237,17 @@ impl ZipFileData {
         for one_extra_field in &self.extra_fields.inner {
             match one_extra_field {
                 // Zip64 extended information extra field
-                ExtraField::Zip64ExtendedInformation {
-                    uncompressed_size,
-                    compressed_size,
-                    header_start,
-                } => {
+                ExtraField::Zip64ExtendedInformation(zip64_block) => {
                     self.large_file = true;
-                    if let Some(uncomp_size) = *uncompressed_size {
-                        self.uncompressed_size = uncomp_size;
+                    if let Some(Zip64Sizes {
+                        uncompressed_size,
+                        compressed_size,
+                    }) = zip64_block.sizes
+                    {
+                        self.uncompressed_size = uncompressed_size;
+                        self.compressed_size = compressed_size;
                     }
-                    if let Some(comp_size) = *compressed_size {
-                        self.compressed_size = comp_size;
-                    }
-                    if let Some(head_start) = *header_start {
+                    if let Some(head_start) = zip64_block.header_start {
                         self.header_start = head_start;
                     }
                 }

--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -14,13 +14,14 @@ mod zip64_extended_information;
 mod zipinfo_utf8;
 
 pub(crate) use aex_encryption::AexEncryption;
-pub(crate) use zip64_extended_information::Zip64ExtendedInformation;
+pub use zip64_extended_information::Zip64Sizes;
 
 // re-export
 pub use data_stream_alignment::DataStreamAlignment;
 pub use extended_timestamp::ExtendedTimestamp;
 pub use extra_field::{ExtraField, ExtraFields};
 pub use ntfs::Ntfs;
+pub use zip64_extended_information::Zip64ExtendedInformation;
 pub use zipinfo_utf8::UnicodeExtraField;
 
 /// Marker trait to denote the place where this extra field has been stored.

--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -14,14 +14,13 @@ mod zip64_extended_information;
 mod zipinfo_utf8;
 
 pub(crate) use aex_encryption::AexEncryption;
-pub use zip64_extended_information::Zip64Sizes;
 
 // re-export
 pub use data_stream_alignment::DataStreamAlignment;
 pub use extended_timestamp::ExtendedTimestamp;
 pub use extra_field::{ExtraField, ExtraFields};
 pub use ntfs::Ntfs;
-pub use zip64_extended_information::Zip64ExtendedInformation;
+pub use zip64_extended_information::{Zip64ExtendedInformation, Zip64Sizes};
 pub use zipinfo_utf8::UnicodeExtraField;
 
 /// Marker trait to denote the place where this extra field has been stored.

--- a/src/extra_fields/zip64_extended_information.rs
+++ b/src/extra_fields/zip64_extended_information.rs
@@ -20,13 +20,19 @@ use crate::{
     result::{ZipResult, invalid},
 };
 
+/// Zip64 Sizes
+/// This entry in the Local header MUST include BOTH original
+/// and compressed file size fields.
+#[derive(Copy, Clone, Debug)]
+pub struct Zip64Sizes {
+    pub(crate) uncompressed_size: u64,
+    pub(crate) compressed_size: u64,
+}
+
 /// Zip64 extended information extra field
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct Zip64ExtendedInformation {
-    /// The local header does not contains any `header_start`
-    is_local_header: bool,
-    pub(crate) uncompressed_size: Option<u64>,
-    pub(crate) compressed_size: Option<u64>,
+pub struct Zip64ExtendedInformation {
+    pub(crate) sizes: Option<Zip64Sizes>,
     pub(crate) header_start: Option<u64>,
     // Not used field
     // disk_start: Option<u32>
@@ -49,16 +55,16 @@ impl Zip64ExtendedInformation {
         if !should_add_size {
             return None;
         }
-        let uncompressed_size = Some(uncompressed_size);
-        let compressed_size = Some(compressed_size);
+        let sizes = Some(Zip64Sizes {
+            uncompressed_size,
+            compressed_size,
+        });
 
         // TODO: (unsupported for now)
         // Disk Start Number  4 bytes    Number of the disk on which this file starts
 
         Some(Self {
-            is_local_header: true,
-            uncompressed_size,
-            compressed_size,
+            sizes,
             header_start: None,
         })
     }
@@ -70,15 +76,15 @@ impl Zip64ExtendedInformation {
         header_start: u64,
     ) -> Option<Self> {
         let mut size: u16 = 0;
-        let uncompressed_size = if is_large_file || uncompressed_size >= ZIP64_BYTES_THR {
-            size += mem::size_of::<u64>() as u16;
-            Some(uncompressed_size)
-        } else {
-            None
-        };
-        let compressed_size = if is_large_file || compressed_size >= ZIP64_BYTES_THR {
-            size += mem::size_of::<u64>() as u16;
-            Some(compressed_size)
+        let sizes = if is_large_file
+            || uncompressed_size >= ZIP64_BYTES_THR
+            || compressed_size > ZIP64_BYTES_THR
+        {
+            size += mem::size_of::<u64>() as u16 + mem::size_of::<u64>() as u16;
+            Some(Zip64Sizes {
+                uncompressed_size,
+                compressed_size,
+            })
         } else {
             None
         };
@@ -97,35 +103,36 @@ impl Zip64ExtendedInformation {
         }
 
         Some(Self {
-            is_local_header: false,
-            uncompressed_size,
-            compressed_size,
+            sizes,
             header_start,
         })
     }
 
-    pub(crate) fn size(&self) -> usize {
+    pub(crate) fn full_size(&self, is_local_header: bool) -> usize {
+        mem::size_of::<UsedExtraField>() + mem::size_of::<u16>() + self.size(is_local_header)
+    }
+
+    pub(crate) fn size(&self, is_local_header: bool) -> usize {
         let mut size = 0;
-        if self.uncompressed_size.is_some() {
-            size += mem::size_of::<u64>();
+        if self.sizes.is_some() {
+            size += mem::size_of::<u64>() + mem::size_of::<u64>();
         }
-        if self.compressed_size.is_some() {
-            size += mem::size_of::<u64>();
-        }
-        if self.header_start.is_some() {
+        if !is_local_header && self.header_start.is_some() {
             size += mem::size_of::<u64>();
         }
         size
     }
 
     /// Serialize the block
-    pub fn write<T: Write>(self, writer: &mut T) -> ZipResult<()> {
+    pub fn write<T: Write>(self, writer: &mut T, is_local_header: bool) -> ZipResult<()> {
         writer.write_all(&Self::MAGIC.to_le_bytes())?;
 
-        if self.is_local_header {
+        if is_local_header {
             // the local header does not contains the header start
-            if let (Some(uncompressed_size), Some(compressed_size)) =
-                (self.uncompressed_size, self.compressed_size)
+            if let Some(Zip64Sizes {
+                uncompressed_size,
+                compressed_size,
+            }) = self.sizes
             {
                 let size = (mem::size_of::<u64>() + mem::size_of::<u64>()) as u16;
                 writer.write_all(&size.to_le_bytes())?;
@@ -134,12 +141,14 @@ impl Zip64ExtendedInformation {
             }
             // the else should be unreachable
         } else {
-            let size = self.size() as u16;
+            let size = self.size(is_local_header) as u16;
             writer.write_all(&size.to_le_bytes())?;
-            if let Some(uncompressed_size) = self.uncompressed_size {
+            if let Some(Zip64Sizes {
+                uncompressed_size,
+                compressed_size,
+            }) = self.sizes
+            {
                 writer.write_all(&u64::to_le_bytes(uncompressed_size))?;
-            }
-            if let Some(compressed_size) = self.compressed_size {
                 writer.write_all(&u64::to_le_bytes(compressed_size))?;
             }
             if let Some(header_start) = self.header_start {

--- a/src/extra_fields/zip64_extended_information.rs
+++ b/src/extra_fields/zip64_extended_information.rs
@@ -120,7 +120,7 @@ impl Zip64ExtendedInformation {
     }
 
     /// Serialize the block
-    pub fn write<T: Write>(self, writer: &mut T, is_local_header: bool) -> ZipResult<()> {
+    pub fn write<T: Write>(&self, writer: &mut T, is_local_header: bool) -> ZipResult<()> {
         writer.write_all(&Self::MAGIC.to_le_bytes())?;
         let size = self.size(is_local_header) as u16;
         writer.write_all(&size.to_le_bytes())?;

--- a/src/extra_fields/zip64_extended_information.rs
+++ b/src/extra_fields/zip64_extended_information.rs
@@ -34,7 +34,8 @@ pub struct Zip64Sizes {
 pub struct Zip64ExtendedInformation {
     pub(crate) sizes: Option<Zip64Sizes>,
     pub(crate) header_start: Option<u64>,
-    // Not used field
+    // TODO: (unsupported for now)
+    // Disk Start Number  4 bytes    Number of the disk on which this file starts
     // disk_start: Option<u32>
 }
 
@@ -55,16 +56,11 @@ impl Zip64ExtendedInformation {
         if !should_add_size {
             return None;
         }
-        let sizes = Some(Zip64Sizes {
-            uncompressed_size,
-            compressed_size,
-        });
-
-        // TODO: (unsupported for now)
-        // Disk Start Number  4 bytes    Number of the disk on which this file starts
-
         Some(Self {
-            sizes,
+            sizes: Some(Zip64Sizes {
+                uncompressed_size,
+                compressed_size,
+            }),
             header_start: None,
         })
     }

--- a/src/extra_fields/zip64_extended_information.rs
+++ b/src/extra_fields/zip64_extended_information.rs
@@ -126,34 +126,20 @@ impl Zip64ExtendedInformation {
     /// Serialize the block
     pub fn write<T: Write>(self, writer: &mut T, is_local_header: bool) -> ZipResult<()> {
         writer.write_all(&Self::MAGIC.to_le_bytes())?;
+        let size = self.size(is_local_header) as u16;
+        writer.write_all(&size.to_le_bytes())?;
+        if let Some(Zip64Sizes {
+            uncompressed_size,
+            compressed_size,
+        }) = self.sizes
+        {
+            writer.write_all(&u64::to_le_bytes(uncompressed_size))?;
+            writer.write_all(&u64::to_le_bytes(compressed_size))?;
+        }
 
-        if is_local_header {
-            // the local header does not contains the header start
-            if let Some(Zip64Sizes {
-                uncompressed_size,
-                compressed_size,
-            }) = self.sizes
-            {
-                let size = (mem::size_of::<u64>() + mem::size_of::<u64>()) as u16;
-                writer.write_all(&size.to_le_bytes())?;
-                writer.write_all(&u64::to_le_bytes(uncompressed_size))?;
-                writer.write_all(&u64::to_le_bytes(compressed_size))?;
-            }
-            // the else should be unreachable
-        } else {
-            let size = self.size(is_local_header) as u16;
-            writer.write_all(&size.to_le_bytes())?;
-            if let Some(Zip64Sizes {
-                uncompressed_size,
-                compressed_size,
-            }) = self.sizes
-            {
-                writer.write_all(&u64::to_le_bytes(uncompressed_size))?;
-                writer.write_all(&u64::to_le_bytes(compressed_size))?;
-            }
-            if let Some(header_start) = self.header_start {
-                writer.write_all(&u64::to_le_bytes(header_start))?;
-            }
+        // the local header does not contains the header start
+        if !is_local_header && let Some(header_start) = self.header_start {
+            writer.write_all(&u64::to_le_bytes(header_start))?;
         }
         Ok(())
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -8,7 +8,7 @@ use crate::extra_fields::AexEncryption;
 use crate::extra_fields::CustomExtraField;
 use crate::extra_fields::DataStreamAlignment;
 use crate::extra_fields::ExtraFields;
-use crate::extra_fields::Zip64ExtendedInformation;
+use crate::extra_fields::{Zip64ExtendedInformation, Zip64Sizes};
 use crate::format::flags::ZipFlags;
 use crate::read::{Config, ZipArchive, ZipFile};
 use crate::result::{ZipError, ZipResult, invalid};
@@ -2417,7 +2417,7 @@ impl ZipFileData {
             + file_name_raw.len() as u64;
 
         writer.seek(SeekFrom::Start(zip64_extra_field_start))?;
-        zip64_block.write(writer)?;
+        zip64_block.write(writer, true)?;
         Ok(())
     }
 
@@ -2428,16 +2428,13 @@ impl ZipFileData {
     ) -> ZipResult<()> {
         let mut zip64_field_is_present = false;
         for one_extra_field in self.extra_fields.inner.iter_mut() {
-            if let ExtraField::Zip64ExtendedInformation {
-                compressed_size,
-                uncompressed_size,
-                header_start,
-            } = one_extra_field
-            {
-                *compressed_size = Some(self.compressed_size);
-                *uncompressed_size = Some(self.uncompressed_size);
+            if let ExtraField::Zip64ExtendedInformation(zip64_block) = one_extra_field {
+                zip64_block.sizes = Some(Zip64Sizes {
+                    uncompressed_size: self.uncompressed_size,
+                    compressed_size: self.compressed_size,
+                });
                 if self.header_start >= ZIP64_BYTES_THR {
-                    *header_start = Some(self.header_start);
+                    zip64_block.header_start = Some(self.header_start);
                 }
                 zip64_field_is_present = true;
             }
@@ -2450,26 +2447,9 @@ impl ZipFileData {
                 self.compressed_size,
                 self.header_start,
             ) {
-                if zip64_block.uncompressed_size.is_some() || zip64_block.compressed_size.is_some()
-                {
-                    self.extra_fields.inner.insert(
-                        0,
-                        ExtraField::Zip64ExtendedInformation {
-                            compressed_size: zip64_block.compressed_size,
-                            uncompressed_size: zip64_block.uncompressed_size,
-                            header_start: zip64_block.header_start,
-                        },
-                    );
-                } else {
-                    self.extra_fields.inner.insert(
-                        0,
-                        ExtraField::Zip64ExtendedInformation {
-                            compressed_size: None,
-                            uncompressed_size: None,
-                            header_start: zip64_block.header_start,
-                        },
-                    );
-                }
+                self.extra_fields
+                    .inner
+                    .insert(0, ExtraField::Zip64ExtendedInformation(zip64_block));
             }
         }
         let central_extra_fields = self.extra_fields.central_extra_fields();
@@ -2564,11 +2544,13 @@ impl ZipFileData {
             // the update function need the extra field to be at index 0
             self.extra_fields.inner.insert(
                 0,
-                ExtraField::Zip64ExtendedInformation {
-                    compressed_size: Some(u64::MAX),
-                    uncompressed_size: Some(u64::MAX),
+                ExtraField::Zip64ExtendedInformation(Zip64ExtendedInformation {
+                    sizes: Some(Zip64Sizes {
+                        compressed_size: u64::MAX,
+                        uncompressed_size: u64::MAX,
+                    }),
                     header_start: None,
-                },
+                }),
             );
         }
         let (compressed_size, uncompressed_size) = if self.is_using_data_descriptor() {


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
