### PR TITLE
chore: release v9.0.0-pre3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0-pre3.1](https://github.com/zip-rs/zip2/compare/v9.0.0-pre3...v9.0.0-pre3.1) - 2026-08-16
+
+### <!-- 0 -->🚀 Features
+
+- use ZipFileEntry instead of ZipStreamFileMetadata ([#935](https://github.com/zip-rs/zip2/pull/935))
+- add ZipFileEntry with no Reader ([#933](https://github.com/zip-rs/zip2/pull/933))
+- change `aes_mode` to `aes_settings()` in ZipFileData ([#925](https://github.com/zip-rs/zip2/pull/925))
+- cleanup and harmonize extra fields ([#923](https://github.com/zip-rs/zip2/pull/923))
+- Rewrite zip64 extra ([#913](https://github.com/zip-rs/zip2/pull/913))
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- lazy allocation on error case ([#937](https://github.com/zip-rs/zip2/pull/937))
+- fix data alignement ([#929](https://github.com/zip-rs/zip2/pull/929))
+
+### <!-- 2 -->🚜 Refactor
+
+- simplify `initialize_local_block` ([#934](https://github.com/zip-rs/zip2/pull/934))
+- move write options to `write/options.rs` ([#931](https://github.com/zip-rs/zip2/pull/931))
+- move spec to format ([#932](https://github.com/zip-rs/zip2/pull/932))
+- move Magic to format ([#930](https://github.com/zip-rs/zip2/pull/930))
+- [**breaking**] Remove ZipFileData::extra_data_start field that is never read ([#926](https://github.com/zip-rs/zip2/pull/926))
+
 ## [9.0.0-pre3](https://github.com/zip-rs/zip2/compare/v9.0.0-pre2...v9.0.0-pre3) - 2026-08-10
 
 ### <!-- 0 -->🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### <!-- 1 -->🐛 Bug Fixes
 
 - lazy allocation on error case ([#937](https://github.com/zip-rs/zip2/pull/937))
-- fix: the alignment value should be inside the data alignement ([#929](https://github.com/zip-rs/zip2/pull/929))
+- fix: the alignment value should be inside the data alignment ([#929](https://github.com/zip-rs/zip2/pull/929))
 
 ### <!-- 2 -->🚜 Refactor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### <!-- 1 -->🐛 Bug Fixes
 
 - lazy allocation on error case ([#937](https://github.com/zip-rs/zip2/pull/937))
-- fix data alignement ([#929](https://github.com/zip-rs/zip2/pull/929))
+- fix: the alignment value should be inside the data alignement ([#929](https://github.com/zip-rs/zip2/pull/929))
 
 ### <!-- 2 -->🚜 Refactor
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "9.0.0-pre3"
+version = "9.0.0-pre3.1"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION



## 🤖 New release

* `zip`: 9.0.0-pre3 -> 9.0.0-pre3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [9.0.0-pre3.1](https://github.com/zip-rs/zip2/compare/v9.0.0-pre3...v9.0.0-pre3.1) - 2026-08-16

### <!-- 0 -->🚀 Features

- use ZipFileEntry instead of ZipStreamFileMetadata ([#935](https://github.com/zip-rs/zip2/pull/935))
- add ZipFileEntry with no Reader ([#933](https://github.com/zip-rs/zip2/pull/933))
- change `aes_mode` to `aes_settings()` in ZipFileData ([#925](https://github.com/zip-rs/zip2/pull/925))
- cleanup and harmonize extra fields ([#923](https://github.com/zip-rs/zip2/pull/923))
- Rewrite zip64 extra ([#913](https://github.com/zip-rs/zip2/pull/913))

### <!-- 1 -->🐛 Bug Fixes

- lazy allocation on error case ([#937](https://github.com/zip-rs/zip2/pull/937))
- fix data alignement ([#929](https://github.com/zip-rs/zip2/pull/929))

### <!-- 2 -->🚜 Refactor

- simplify `initialize_local_block` ([#934](https://github.com/zip-rs/zip2/pull/934))
- move write options to `write/options.rs` ([#931](https://github.com/zip-rs/zip2/pull/931))
- move spec to format ([#932](https://github.com/zip-rs/zip2/pull/932))
- move Magic to format ([#930](https://github.com/zip-rs/zip2/pull/930))
- [**breaking**] Remove ZipFileData::extra_data_start field that is never read ([#926](https://github.com/zip-rs/zip2/pull/926))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).