### PR TITLE
refactor!: Remove ZipFileData::extra_data_start field that is never read

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -499,7 +499,6 @@ fn central_header_to_zip_file_inner<R: Read>(
         flags,
         file_comment,
         header_start: offset.into(),
-        extra_data_start: None,
         central_header_start,
         data_start: OnceLock::new(),
         external_attributes: external_file_attributes,

--- a/src/types.rs
+++ b/src/types.rs
@@ -124,8 +124,6 @@ pub struct ZipFileData {
     pub file_comment: Box<str>,
     /// Specifies where the local header of the file starts
     pub header_start: u64,
-    /// Specifies where the extra data of the file starts
-    pub extra_data_start: Option<u64>,
     /// Specifies where the central header of the file starts
     ///
     /// Note that when this is not known, it is set to 0
@@ -354,7 +352,6 @@ impl ZipFileData {
         options: &FileOptions<'_, '_, T>,
         raw_values: &ZipRawValues,
         header_start: u64,
-        extra_data_start: Option<u64>,
         compression_method: CompressionMethod,
         extra_fields: ExtraFields,
     ) -> Self {
@@ -416,7 +413,6 @@ impl ZipFileData {
             external_attributes,
             large_file: options.large_file,
             extra_fields,
-            extra_data_start,
         };
         local_block.version_made_by = local_block.version_needed() as u8;
         local_block
@@ -461,7 +457,6 @@ impl ZipFileData {
             external_attributes: 0,
             large_file: false,
             extra_fields,
-            extra_data_start: None,
         };
         Ok(data)
     }
@@ -593,7 +588,6 @@ mod tests {
             uncompressed_size: 0,
             file_comment: String::with_capacity(0).into_boxed_str(),
             header_start: 0,
-            extra_data_start: None,
             data_start: OnceLock::new(),
             central_header_start: 0,
             external_attributes: 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -346,7 +346,6 @@ impl ZipFileData {
             .max(misc_feature_version)
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn initialize_local_block<T: FileOptionExtension>(
         file_name_raw: &[u8],
         options: &FileOptions<'_, '_, T>,

--- a/src/write.rs
+++ b/src/write.rs
@@ -1185,7 +1185,6 @@ impl<W: Write + Seek> ZipWriter<W> {
             &options,
             &raw_values,
             header_start,
-            None,
             compression_method,
             ExtraFields {
                 inner: extra_fields,

--- a/src/write.rs
+++ b/src/write.rs
@@ -2358,12 +2358,9 @@ fn update_aes_extra_field<W: Write + Seek>(
         .find(|f| matches!(f, ExtraField::AeXEncryption(_)))
     {
         *aes_vendor_version = new_version;
-        let extra_field_start = file
-            .extra_data_start
-            .ok_or_else(|| std::io::Error::other("Cannot get the extra data start"))?;
 
         if let Some(aes_start) = aes_extra_field_start {
-            writer.seek(SeekFrom::Start(extra_field_start + *aes_start as u64))?;
+            writer.seek(SeekFrom::Start(*aes_start as u64))?;
         } else {
             return Err(invalid!("The AES extra field should have a known start"));
         }
@@ -2633,7 +2630,6 @@ impl ZipFileData {
         } else {
             None
         };
-        self.extra_data_start = Some(header_end);
         let data_start = header_end + extra_field_len as u64;
         self.data_start.take();
         self.data_start.get_or_init(|| data_start);
@@ -2670,7 +2666,7 @@ impl ZipFileData {
                     ..
                 }) = one_extra_field
                 {
-                    *aes_extra_field_start = Some(bytes_written);
+                    *aes_extra_field_start = Some(header_end as usize + bytes_written);
                 }
                 bytes_written += one_extra_field.size(true);
             }


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
