### PR TITLE
test: Verify that alignment padding isn't written to central directory

### DIFF
--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -183,9 +183,9 @@ pub struct CustomExtraField {
     /// If true, this field will be included in the central directory entry but not the local file header.
     pub(crate) central_only: bool,
     /// Header ID of the extra field
-    pub(crate) header_id: u16,
+    pub header_id: u16,
     /// Data of the extra field
-    data: Box<[u8]>,
+    pub data: Box<[u8]>,
 }
 
 impl CustomExtraField {

--- a/tests/zip_extra_field.rs
+++ b/tests/zip_extra_field.rs
@@ -182,8 +182,8 @@ fn test_extra_field_too_long() {
 #[test]
 fn test_alignment_extra_field_local_only() {
     use std::io::{Cursor, Write};
-    use zip::write::{SimpleFileOptions, ZipWriter};
     use zip::ZipArchive;
+    use zip::write::{SimpleFileOptions, ZipWriter};
 
     let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
     let options = SimpleFileOptions::default().with_alignment(16);
@@ -193,14 +193,21 @@ fn test_alignment_extra_field_local_only() {
 
     // Verify 0xa11e alignment tag is present in the local header bytes
     let tag = (0xa11e_u16).to_le_bytes();
-    assert_eq!(zip_bytes.windows(2).filter(|w| *w == tag).count(), 1, "Local header must contain alignment extra field tag 0xa11e");
+    assert_eq!(
+        zip_bytes.windows(2).filter(|w| *w == tag).count(),
+        1,
+        "Local header must contain alignment extra field tag 0xa11e"
+    );
 
     // Central directory should not contain DataStreamAlignment
     let mut archive = ZipArchive::new(Cursor::new(&zip_bytes)).unwrap();
     let file = archive.by_name("test.txt").unwrap();
-    let has_alignment_central = file
-        .extra_data_fields()
-        .any(|ef| matches!(ef, zip::extra_fields::ExtraField::DataStreamAlignment { .. }));
+    let has_alignment_central = file.extra_data_fields().any(|ef| {
+        matches!(
+            ef,
+            zip::extra_fields::ExtraField::DataStreamAlignment { .. }
+        )
+    });
     assert!(
         !has_alignment_central,
         "Central directory header must NOT contain DataStreamAlignment"
@@ -210,13 +217,15 @@ fn test_alignment_extra_field_local_only() {
 #[test]
 fn test_custom_central_only_extra_field() {
     use std::io::{Cursor, Write};
+    use zip::ZipArchive;
     use zip::extra_fields::ExtraField;
     use zip::write::{FileOptions, ZipWriter};
-    use zip::ZipArchive;
 
     let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
     let mut options = FileOptions::default();
-    options.add_extra_field(0x1234, vec![0xAB, 0xCD], true).unwrap(); // central_only = true
+    options
+        .add_extra_field(0x1234, vec![0xAB, 0xCD], true)
+        .unwrap(); // central_only = true
 
     writer.start_file("central_only.txt", options).unwrap();
     writer.write_all(b"content").unwrap();
@@ -230,6 +239,8 @@ fn test_custom_central_only_extra_field() {
         ExtraField::Custom(cef) => cef.header_id == 0x1234 && *cef.data == [0xAB, 0xCD],
         _ => false,
     });
-    assert!(has_custom_central, "Central directory header must contain central_only custom field");
+    assert!(
+        has_custom_central,
+        "Central directory header must contain central_only custom field"
+    );
 }
-

--- a/tests/zip_extra_field.rs
+++ b/tests/zip_extra_field.rs
@@ -226,8 +226,7 @@ fn test_custom_central_only_extra_field() {
     use zip::write::{FileOptions, ZipWriter};
 
     let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
-    let mut options = FileOptions::default()
-        .compression_method(CompressionMethod::Stored);
+    let mut options = FileOptions::default().compression_method(CompressionMethod::Stored);
     options
         .add_extra_field(0x1234, vec![0xAB, 0xCD], true)
         .unwrap(); // central_only = true

--- a/tests/zip_extra_field.rs
+++ b/tests/zip_extra_field.rs
@@ -178,3 +178,58 @@ fn test_extra_field_too_long() {
         }
     }
 }
+
+#[test]
+fn test_alignment_extra_field_local_only() {
+    use std::io::{Cursor, Write};
+    use zip::write::{SimpleFileOptions, ZipWriter};
+    use zip::ZipArchive;
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = SimpleFileOptions::default().with_alignment(16);
+    writer.start_file("test.txt", options).unwrap();
+    writer.write_all(b"hello world").unwrap();
+    let zip_bytes = writer.finish().unwrap().into_inner();
+
+    // Verify 0xa11e alignment tag is present in the local header bytes
+    let tag = (0xa11e_u16).to_le_bytes();
+    assert_eq!(zip_bytes.windows(2).filter(|w| *w == tag).count(), 1, "Local header must contain alignment extra field tag 0xa11e");
+
+    // Central directory should not contain DataStreamAlignment
+    let mut archive = ZipArchive::new(Cursor::new(&zip_bytes)).unwrap();
+    let file = archive.by_name("test.txt").unwrap();
+    let has_alignment_central = file
+        .extra_data_fields()
+        .any(|ef| matches!(ef, zip::extra_fields::ExtraField::DataStreamAlignment { .. }));
+    assert!(
+        !has_alignment_central,
+        "Central directory header must NOT contain DataStreamAlignment"
+    );
+}
+
+#[test]
+fn test_custom_central_only_extra_field() {
+    use std::io::{Cursor, Write};
+    use zip::extra_fields::ExtraField;
+    use zip::write::{FileOptions, ZipWriter};
+    use zip::ZipArchive;
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let mut options = FileOptions::default();
+    options.add_extra_field(0x1234, vec![0xAB, 0xCD], true).unwrap(); // central_only = true
+
+    writer.start_file("central_only.txt", options).unwrap();
+    writer.write_all(b"content").unwrap();
+    let bytes = writer.finish().unwrap().into_inner();
+
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).unwrap();
+    let file = archive.by_name("central_only.txt").unwrap();
+
+    // Central directory should have this field
+    let has_custom_central = file.extra_data_fields().any(|ef| match ef {
+        ExtraField::Custom(cef) => cef.header_id == 0x1234 && *cef.data == [0xAB, 0xCD],
+        _ => false,
+    });
+    assert!(has_custom_central, "Central directory header must contain central_only custom field");
+}
+

--- a/tests/zip_extra_field.rs
+++ b/tests/zip_extra_field.rs
@@ -182,11 +182,14 @@ fn test_extra_field_too_long() {
 #[test]
 fn test_alignment_extra_field_local_only() {
     use std::io::{Cursor, Write};
+    use zip::CompressionMethod;
     use zip::ZipArchive;
     use zip::write::{SimpleFileOptions, ZipWriter};
 
     let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
-    let options = SimpleFileOptions::default().with_alignment(16);
+    let options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .with_alignment(16);
     writer.start_file("test.txt", options).unwrap();
     writer.write_all(b"hello world").unwrap();
     let zip_bytes = writer.finish().unwrap().into_inner();
@@ -217,12 +220,14 @@ fn test_alignment_extra_field_local_only() {
 #[test]
 fn test_custom_central_only_extra_field() {
     use std::io::{Cursor, Write};
+    use zip::CompressionMethod;
     use zip::ZipArchive;
     use zip::extra_fields::ExtraField;
     use zip::write::{FileOptions, ZipWriter};
 
     let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
-    let mut options = FileOptions::default();
+    let mut options = FileOptions::default()
+        .compression_method(CompressionMethod::Stored);
     options
         .add_extra_field(0x1234, vec![0xAB, 0xCD], true)
         .unwrap(); // central_only = true


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
