### PR TITLE
fix: the alignment value should be inside the data alignment

### DIFF
--- a/src/extra_fields/data_stream_alignment.rs
+++ b/src/extra_fields/data_stream_alignment.rs
@@ -8,6 +8,8 @@ use crate::extra_fields::UsedExtraField;
 /// Data stream alignment
 #[derive(Debug, Clone, PartialEq)]
 pub struct DataStreamAlignment {
+    /// alignment
+    alignment: u16,
     /// padding length
     pad_len: u16,
 }
@@ -15,10 +17,11 @@ pub struct DataStreamAlignment {
 impl DataStreamAlignment {
     /// create the alignment field using the full alignment len needed
     #[must_use]
-    pub fn new(alignment_len: u16) -> Option<Self> {
-        if alignment_len >= 6 {
+    pub fn new(padding_len: u16, alignment: u16) -> Option<Self> {
+        if padding_len >= 6 {
             Some(Self {
-                pad_len: alignment_len.saturating_sub(4),
+                alignment,
+                pad_len: padding_len.saturating_sub(4),
             })
         } else {
             None
@@ -46,8 +49,8 @@ impl DataStreamAlignment {
         let magic = UsedExtraField::DataStreamAlignment.as_u16();
         writer.write_all(&magic.to_le_bytes())?;
         writer.write_all(&self.pad_len.to_le_bytes())?;
+        writer.write_all(&self.alignment.to_le_bytes())?;
         let pad_len = self.pad_len.saturating_sub(2);
-        writer.write_all(&pad_len.to_le_bytes())?;
         let zeros = [0u8; 1024];
         let mut remaining = pad_len as usize;
         while remaining > 0 {

--- a/src/write.rs
+++ b/src/write.rs
@@ -2611,7 +2611,8 @@ impl ZipFileData {
                     let pad_length_u16: Result<u16, core::num::TryFromIntError> =
                         pad_length.try_into();
                     if let Ok(pad_length) = pad_length_u16
-                        && let Some(alignment_extra_field) = DataStreamAlignment::new(pad_length)
+                        && let Some(alignment_extra_field) =
+                            DataStreamAlignment::new(pad_length, alignment)
                     {
                         // Add an extra field to the extra_field, per APPNOTE 4.6.11
                         extra_field_len = self


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->

Little mistake in github.com/zip-rs/zip2/pull/879

It was previously like this (line 1223)

https://github.com/zip-rs/zip2/blob/98d6d23a948e904c161601e37556d4c01058d446/src/write.rs#L1221-L1229

But the alignment is not written to