### PR TITLE
refactor: move Magic to format

### DIFF
--- a/src/format/magic.rs
+++ b/src/format/magic.rs
@@ -1,0 +1,42 @@
+//! "Magic" header values used in the zip spec to locate metadata records.
+
+/// These values currently always take up a fixed four bytes, so we can parse and wrap them in this
+/// struct to enforce some small amount of type safety.
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub(crate) struct Magic(u32);
+
+impl Magic {
+    pub const LOCAL_FILE_HEADER_SIGNATURE: Self = Self::literal(0x0403_4b50);
+    pub const CENTRAL_DIRECTORY_HEADER_SIGNATURE: Self = Self::literal(0x0201_4b50);
+    pub const CENTRAL_DIRECTORY_END_SIGNATURE: Self = Self::literal(0x0605_4b50);
+    pub const ZIP64_CENTRAL_DIRECTORY_END_SIGNATURE: Self = Self::literal(0x0606_4b50);
+    pub const ZIP64_CENTRAL_DIRECTORY_END_LOCATOR_SIGNATURE: Self = Self::literal(0x0706_4b50);
+    pub const DATA_DESCRIPTOR_SIGNATURE: Self = Self::literal(0x0807_4b50);
+
+    pub const fn literal(x: u32) -> Self {
+        Self(x)
+    }
+
+    #[inline(always)]
+    pub const fn from_le_bytes(bytes: [u8; 4]) -> Self {
+        Self(u32::from_le_bytes(bytes))
+    }
+
+    #[inline(always)]
+    pub const fn to_le_bytes(self) -> [u8; 4] {
+        self.0.to_le_bytes()
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    #[inline(always)]
+    pub fn from_le(self) -> Self {
+        Self(u32::from_le(self.0))
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    #[inline(always)]
+    pub fn to_le(self) -> Self {
+        Self(u32::to_le(self.0))
+    }
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -2,3 +2,4 @@
 
 pub(crate) mod aes;
 pub(crate) mod flags;
+pub(crate) mod magic;

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -2,12 +2,13 @@
 
 use crate::ZipReadOptions;
 use crate::extra_fields::ExtraFields;
+use crate::format::magic::Magic;
 use crate::read::readers::{make_crypto_reader, make_reader};
 use crate::read::{
     ZipFile, ZipFileData, ZipResult, central_header_to_zip_file_inner, make_symlink,
 };
 use crate::result::{ZipError, invalid};
-use crate::spec::{FixedSizeBlock, Magic, Pod, ZipCentralEntryBlock, ZipLocalEntryBlock};
+use crate::spec::{FixedSizeBlock, Pod, ZipCentralEntryBlock, ZipLocalEntryBlock};
 
 use indexmap::IndexMap;
 use std::borrow::Cow;

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,5 +1,6 @@
 //! Code linked with the specifications of the zip file
 
+use crate::format::magic::Magic;
 use crate::read::ArchiveOffset;
 use crate::read::magic_finder::{Backwards, Forward, MagicFinder, OptimisticMagicFinder};
 use crate::result::{ZipError, ZipResult, invalid};
@@ -7,51 +8,6 @@ use core::any::type_name;
 use core::mem;
 use core::slice;
 use std::io::{self, Read, Seek, Write};
-
-/// "Magic" header values used in the zip spec to locate metadata records.
-///
-/// These values currently always take up a fixed four bytes, so we can parse and wrap them in this
-/// struct to enforce some small amount of type safety.
-#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
-#[repr(transparent)]
-pub(crate) struct Magic(u32);
-
-impl Magic {
-    pub const fn literal(x: u32) -> Self {
-        Self(x)
-    }
-
-    #[inline(always)]
-    #[allow(dead_code)]
-    pub const fn from_le_bytes(bytes: [u8; 4]) -> Self {
-        Self(u32::from_le_bytes(bytes))
-    }
-
-    #[inline(always)]
-    pub const fn to_le_bytes(self) -> [u8; 4] {
-        self.0.to_le_bytes()
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    #[allow(unused)]
-    #[inline(always)]
-    pub fn from_le(self) -> Self {
-        Self(u32::from_le(self.0))
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    #[inline(always)]
-    pub fn to_le(self) -> Self {
-        Self(u32::to_le(self.0))
-    }
-
-    pub const LOCAL_FILE_HEADER_SIGNATURE: Self = Self::literal(0x0403_4b50);
-    pub const CENTRAL_DIRECTORY_HEADER_SIGNATURE: Self = Self::literal(0x0201_4b50);
-    pub const CENTRAL_DIRECTORY_END_SIGNATURE: Self = Self::literal(0x0605_4b50);
-    pub const ZIP64_CENTRAL_DIRECTORY_END_SIGNATURE: Self = Self::literal(0x0606_4b50);
-    pub const ZIP64_CENTRAL_DIRECTORY_END_LOCATOR_SIGNATURE: Self = Self::literal(0x0706_4b50);
-    pub const DATA_DESCRIPTOR_SIGNATURE: Self = Self::literal(0x0807_4b50);
-}
 
 /// The file size at which a ZIP64 record becomes necessary.
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,13 +7,13 @@ use crate::extra_fields::ExtraFields;
 use crate::format::aes::{AesMode, AesVendorVersion};
 use crate::format::flags::System;
 use crate::format::flags::ZipFlags;
+use crate::format::magic::Magic;
 use crate::path::{enclosed_name, file_name_sanitized};
 use crate::read::readers::SeekableTake;
 use crate::result::{ZipError, ZipResult};
 use crate::spec::is_dir;
 use crate::spec::{
-    self, FixedSizeBlock, Magic, Zip64DataDescriptorBlock, ZipDataDescriptorBlock,
-    ZipLocalEntryBlock,
+    self, FixedSizeBlock, Zip64DataDescriptorBlock, ZipDataDescriptorBlock, ZipLocalEntryBlock,
 };
 use crate::write::FileOptionExtension;
 use crate::zipcrypto::ZipCryptoKeys;

--- a/src/write.rs
+++ b/src/write.rs
@@ -10,11 +10,12 @@ use crate::extra_fields::ExtraFields;
 use crate::extra_fields::{Zip64ExtendedInformation, Zip64Sizes};
 use crate::format::flags::System;
 use crate::format::flags::ZipFlags;
+use crate::format::magic::Magic;
 use crate::read::{Config, ZipArchive, ZipFile};
 use crate::result::{ZipError, ZipResult, invalid};
 use crate::spec::{
-    self, FixedSizeBlock, Magic, Zip32CDEBlock, Zip64CentralDirectoryEnd,
-    Zip64CentralDirectoryEndLocator, ZipCentralEntryBlock, ZipLocalEntryBlock,
+    self, FixedSizeBlock, Zip32CDEBlock, Zip64CentralDirectoryEnd, Zip64CentralDirectoryEndLocator,
+    ZipCentralEntryBlock, ZipLocalEntryBlock,
 };
 use crate::types::EncryptWith;
 use crate::types::{MIN_VERSION, ZipFileData, ZipRawValues, ffi};
@@ -4702,7 +4703,7 @@ mod tests {
 
     #[test]
     fn test_max_len_extra_field() {
-        use crate::spec::Magic;
+        use crate::format::magic::Magic;
         use crate::spec::ZipLocalEntryBlock;
         assert_eq!(std::mem::size_of::<Magic>(), 4);
         assert_eq!(std::mem::size_of::<ZipLocalEntryBlock>(), 26);


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
