### PR TITLE
feat: add ZipFileEntry with no Reader

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod ffi {
 ///
 /// If a file larger than this threshold attempts to be written, compressed or uncompressed, and
 /// [`FileOptions::large_file()`](crate::write::FileOptions::large_file) was not true, then [`crate::ZipWriter`] will
-/// raise an [`io::Error`] with [`io::ErrorKind::Other`].
+/// raise an [`std::io::Error`] with [`std::io::ErrorKind::Other`].
 ///
 /// If the zip file itself is larger than this value, then a zip64 central directory record will be
 /// written to the end of the file.

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod magic_finder;
 pub(crate) mod readers;
 
 pub(crate) mod zipfile;
-pub use zipfile::{ZipFile, ZipFileSeek, ZipFileEntry};
+pub use zipfile::{ZipFile, ZipFileEntry, ZipFileSeek};
 
 pub(crate) mod zip_archive;
 pub use zip_archive::{ZipArchive, ZipArchiveMetadata};

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod magic_finder;
 pub(crate) mod readers;
 
 pub(crate) mod zipfile;
-pub use zipfile::{ZipFile, ZipFileSeek};
+pub use zipfile::{ZipFile, ZipFileSeek, ZipFileEntry};
 
 pub(crate) mod zip_archive;
 pub use zip_archive::{ZipArchive, ZipArchiveMetadata};

--- a/src/read/zip_archive.rs
+++ b/src/read/zip_archive.rs
@@ -5,6 +5,7 @@ use crate::format::blocks::{FixedSizeBlock, ZipCentralEntryBlock};
 use crate::format::functions::find_central_directory;
 use crate::read::config::Config;
 use crate::read::readers::{ZipFileReader, ZipFileSeekReader, make_crypto_reader, make_reader};
+use crate::read::zipfile::ZipFileEntry;
 use crate::read::{
     ArchiveOffset, CentralDirectoryInfo, RootDirFilter, ZipFile, ZipFileSeek, ZipReadOptions,
     central_header_to_zip_file_inner,
@@ -482,7 +483,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             .files
             .get_index(index)
             .ok_or(ZipError::FileNotFound)
-            .and_then(move |(_, data)| {
+            .and_then(move |(file_name_raw, data)| {
                 let seek_reader = match data.compression_method {
                     CompressionMethod::Stored => {
                         ZipFileSeekReader::Raw(data.find_content_seek(reader)?)
@@ -494,6 +495,7 @@ impl<R: Read + Seek> ZipArchive<R> {
                     }
                 };
                 Ok(ZipFileSeek {
+                    file_name_raw: Cow::Borrowed(file_name_raw),
                     reader: seek_reader,
                     data: Cow::Borrowed(data),
                 })
@@ -535,6 +537,19 @@ impl<R: Read + Seek> ZipArchive<R> {
     /// Get a contained file by index
     pub fn by_index(&mut self, file_number: usize) -> ZipResult<ZipFile<'_, R>> {
         self.by_index_with_options(file_number, ZipReadOptions::new())
+    }
+
+    /// Get a contained file by index
+    pub fn by_index_data(&self, file_number: usize) -> ZipResult<ZipFileEntry<'_>> {
+        let (file_name_raw, data) = self
+            .shared
+            .files
+            .get_index(file_number)
+            .ok_or(ZipError::FileNotFound)?;
+        Ok(ZipFileEntry {
+            file_name_raw: Cow::Borrowed(file_name_raw),
+            data: Cow::Borrowed(data),
+        })
     }
 
     /// Get a contained file by index without decompressing it

--- a/src/read/zipfile.rs
+++ b/src/read/zipfile.rs
@@ -32,79 +32,167 @@ pub struct ZipFile<'a, R: Read + ?Sized> {
     pub(crate) reader: ZipFileReader<'a, R>,
 }
 
+/// A struct for reading a zip file, without a reader
+#[derive(Debug)]
+pub struct ZipFileEntry<'a> {
+    pub(crate) file_name_raw: Cow<'a, [u8]>,
+    pub(crate) data: Cow<'a, ZipFileData>,
+}
+
 /// A struct for reading and seeking a zip file
 pub struct ZipFileSeek<'a, R> {
+    pub(crate) file_name_raw: Cow<'a, [u8]>,
     pub(crate) data: Cow<'a, ZipFileData>,
     pub(crate) reader: ZipFileSeekReader<'a, R>,
 }
 
+macro_rules! zip_file_methods {
+    () => {
+        /// Get the name of the file, in the raw (internal) byte representation.
+        ///
+        /// The encoding of this data is currently undefined.
+        pub fn name_raw(&self) -> &[u8] {
+            &self.file_name_raw
+        }
+
+        /// Get the name of the file
+        ///
+        /// # Warnings
+        ///
+        /// It is dangerous to use this name directly when extracting an archive.
+        /// It may contain an absolute path (`/etc/shadow`), or break out of the
+        /// current directory (`../runtime`). Carelessly writing to these paths
+        /// allows an attacker to craft a ZIP archive that will overwrite critical
+        /// files.
+        ///
+        /// You can use the [`ZipFile::enclosed_name`] method to validate the name
+        /// as a safe path.
+        pub fn name(&self) -> ZipResult<Cow<'_, str>> {
+            self.get_metadata().name(&self.file_name_raw)
+        }
+
+        /// Rewrite the path, ignoring any path components with special meaning.
+        ///
+        /// - Absolute paths are made relative
+        /// - [`ParentDir`]s are ignored
+        /// - Truncates the filename at a NULL byte
+        ///
+        /// This is appropriate if you need to be able to extract *something* from
+        /// any archive, but will easily misrepresent trivial paths like
+        /// `foo/../bar` as `foo/bar` (instead of `bar`). Because of this,
+        /// [`ZipFile::enclosed_name`] is the better option in most scenarios.
+        ///
+        /// [`ParentDir`]: `Component::ParentDir`
+        pub fn mangled_name(&self) -> ZipResult<PathBuf> {
+            let file_name = self.name()?;
+            let sanitized = self.get_metadata().file_name_sanitized(&file_name);
+            Ok(sanitized)
+        }
+
+        /// Ensure the file path is safe to use as a [`Path`].
+        ///
+        /// - It can't contain NULL bytes
+        /// - It can't resolve to a path outside the current directory
+        ///   > `foo/../bar` is fine, `foo/../../bar` is not.
+        /// - It can't be an absolute path
+        ///
+        /// This will read well-formed ZIP files correctly, and is resistant
+        /// to path-based exploits. It is recommended over
+        /// [`ZipFile::mangled_name`].
+        pub fn enclosed_name(&self) -> Option<PathBuf> {
+            self.get_metadata().enclosed_name(&self.name().ok()?)
+        }
+
+        /// Get the starting offset of the zip header for this file
+        pub fn header_start(&self) -> u64 {
+            self.get_metadata().header_start
+        }
+        /// Get the starting offset of the zip header in the central directory for this file
+        pub fn central_header_start(&self) -> u64 {
+            self.get_metadata().central_header_start
+        }
+
+        /// Get the version of the file
+        pub fn version_made_by(&self) -> (u8, u8) {
+            (
+                self.get_metadata().version_made_by / 10,
+                self.get_metadata().version_made_by % 10,
+            )
+        }
+
+        /// Get the comment of the file
+        pub fn comment(&self) -> &str {
+            &self.get_metadata().file_comment
+        }
+
+        /// Get the compression method used to store the file
+        pub fn compression(&self) -> CompressionMethod {
+            self.get_metadata().compression_method
+        }
+
+        /// Get if the files is encrypted or not
+        pub fn encrypted(&self) -> bool {
+            self.data.is_encrypted()
+        }
+
+        /// Get the size of the file, in bytes, in the archive
+        pub fn compressed_size(&self) -> u64 {
+            self.get_metadata().compressed_size
+        }
+
+        /// Get the size of the file, in bytes, when uncompressed
+        pub fn size(&self) -> u64 {
+            self.get_metadata().uncompressed_size
+        }
+
+        /// Get the time the file was last modified
+        pub fn last_modified(&self) -> Option<DateTime> {
+            self.get_metadata().last_modified_time
+        }
+        /// Returns whether the file is actually a directory
+        pub fn is_dir(&self) -> bool {
+            self.get_metadata().is_dir(&self.file_name_raw)
+        }
+
+        /// Returns whether the file is actually a symbolic link
+        pub fn is_symlink(&self) -> bool {
+            self.unix_mode()
+                .is_some_and(|mode| mode & ffi::S_IFLNK == ffi::S_IFLNK)
+        }
+
+        /// Returns whether the file is a normal file (i.e. not a directory or symlink)
+        pub fn is_file(&self) -> bool {
+            !self.is_dir() && !self.is_symlink()
+        }
+
+        /// Get unix mode for the file
+        pub fn unix_mode(&self) -> Option<u32> {
+            self.get_metadata().unix_mode()
+        }
+
+        /// Get the CRC32 hash of the original file
+        pub fn crc32(&self) -> u32 {
+            self.get_metadata().crc32
+        }
+    };
+}
+
+impl<'a> ZipFileEntry<'a> {
+    zip_file_methods!();
+}
+
+impl HasZipMetadata for ZipFileEntry<'_> {
+    fn get_metadata(&self) -> &ZipFileData {
+        self.data.as_ref()
+    }
+}
+
 /// Methods for retrieving information on zip files
 impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
+    zip_file_methods!();
+
     pub(crate) fn take_raw_reader(&mut self) -> io::Result<io::Take<&'a mut R>> {
         replace(&mut self.reader, ZipFileReader::NoReader).into_inner()
-    }
-
-    /// Get the version of the file
-    pub fn version_made_by(&self) -> (u8, u8) {
-        (
-            self.get_metadata().version_made_by / 10,
-            self.get_metadata().version_made_by % 10,
-        )
-    }
-
-    /// Get the name of the file
-    ///
-    /// # Warnings
-    ///
-    /// It is dangerous to use this name directly when extracting an archive.
-    /// It may contain an absolute path (`/etc/shadow`), or break out of the
-    /// current directory (`../runtime`). Carelessly writing to these paths
-    /// allows an attacker to craft a ZIP archive that will overwrite critical
-    /// files.
-    ///
-    /// You can use the [`ZipFile::enclosed_name`] method to validate the name
-    /// as a safe path.
-    pub fn name(&self) -> ZipResult<Cow<'_, str>> {
-        self.data.name(&self.file_name_raw)
-    }
-
-    /// Get the name of the file, in the raw (internal) byte representation.
-    ///
-    /// The encoding of this data is currently undefined.
-    pub fn name_raw(&self) -> &[u8] {
-        &self.file_name_raw
-    }
-
-    /// Rewrite the path, ignoring any path components with special meaning.
-    ///
-    /// - Absolute paths are made relative
-    /// - [`ParentDir`]s are ignored
-    /// - Truncates the filename at a NULL byte
-    ///
-    /// This is appropriate if you need to be able to extract *something* from
-    /// any archive, but will easily misrepresent trivial paths like
-    /// `foo/../bar` as `foo/bar` (instead of `bar`). Because of this,
-    /// [`ZipFile::enclosed_name`] is the better option in most scenarios.
-    ///
-    /// [`ParentDir`]: `Component::ParentDir`
-    pub fn mangled_name(&self) -> ZipResult<PathBuf> {
-        let file_name = self.name()?;
-        let sanitized = self.data.file_name_sanitized(&file_name);
-        Ok(sanitized)
-    }
-
-    /// Ensure the file path is safe to use as a [`Path`].
-    ///
-    /// - It can't contain NULL bytes
-    /// - It can't resolve to a path outside the current directory
-    ///   > `foo/../bar` is fine, `foo/../../bar` is not.
-    /// - It can't be an absolute path
-    ///
-    /// This will read well-formed ZIP files correctly, and is resistant
-    /// to path-based exploits. It is recommended over
-    /// [`ZipFile::mangled_name`].
-    pub fn enclosed_name(&self) -> Option<PathBuf> {
-        self.data.enclosed_name(&self.name().ok()?)
     }
 
     /// Prepare the path for extraction by creating necessary missing directories and checking for symlinks to be contained within the base path.
@@ -221,61 +309,6 @@ impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
         Ok(())
     }
 
-    /// Get the comment of the file
-    pub fn comment(&self) -> &str {
-        &self.get_metadata().file_comment
-    }
-
-    /// Get the compression method used to store the file
-    pub fn compression(&self) -> CompressionMethod {
-        self.get_metadata().compression_method
-    }
-
-    /// Get if the files is encrypted or not
-    pub fn encrypted(&self) -> bool {
-        self.data.is_encrypted()
-    }
-
-    /// Get the size of the file, in bytes, in the archive
-    pub fn compressed_size(&self) -> u64 {
-        self.get_metadata().compressed_size
-    }
-
-    /// Get the size of the file, in bytes, when uncompressed
-    pub fn size(&self) -> u64 {
-        self.get_metadata().uncompressed_size
-    }
-
-    /// Get the time the file was last modified
-    pub fn last_modified(&self) -> Option<DateTime> {
-        self.data.last_modified_time
-    }
-    /// Returns whether the file is actually a directory
-    pub fn is_dir(&self) -> bool {
-        self.data.is_dir(&self.file_name_raw)
-    }
-
-    /// Returns whether the file is actually a symbolic link
-    pub fn is_symlink(&self) -> bool {
-        self.unix_mode()
-            .is_some_and(|mode| mode & ffi::S_IFLNK == ffi::S_IFLNK)
-    }
-
-    /// Returns whether the file is a normal file (i.e. not a directory or symlink)
-    pub fn is_file(&self) -> bool {
-        !self.is_dir() && !self.is_symlink()
-    }
-
-    /// Get unix mode for the file
-    pub fn unix_mode(&self) -> Option<u32> {
-        self.get_metadata().unix_mode()
-    }
-
-    /// Get the CRC32 hash of the original file
-    pub fn crc32(&self) -> u32 {
-        self.get_metadata().crc32
-    }
-
     /// Get the extra data of the zip header for this file
     pub fn extra_data(&self) -> Option<Vec<u8>> {
         let out_buffer = Vec::new();
@@ -295,15 +328,6 @@ impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
     /// Get the starting offset of the data of the compressed file
     pub fn data_start(&self) -> Option<u64> {
         self.data.data_start.get().copied()
-    }
-
-    /// Get the starting offset of the zip header for this file
-    pub fn header_start(&self) -> u64 {
-        self.get_metadata().header_start
-    }
-    /// Get the starting offset of the zip header in the central directory for this file
-    pub fn central_header_start(&self) -> u64 {
-        self.get_metadata().central_header_start
     }
 
     /// Get the [`SimpleFileOptions`] that would be used to write this file to
@@ -388,6 +412,10 @@ impl<R> HasZipMetadata for ZipFileSeek<'_, R> {
     fn get_metadata(&self) -> &ZipFileData {
         self.data.as_ref()
     }
+}
+
+impl<'a, R> ZipFileSeek<'a, R> {
+    zip_file_methods!();
 }
 
 impl<R: Read + ?Sized> Drop for ZipFile<'_, R> {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -413,12 +413,12 @@ fn test_zip_file_entry() {
     let file = zip_archive.by_index_data(file_number).unwrap();
     assert_eq!(file.compression(), CompressionMethod::Stored);
 
-    // imagine with when to use it in a callback
+    // we can use it in a callback
     let verify_file = |file: &ZipFileEntry| -> bool { file.size() > 2 };
     let is_correct_size = verify_file(&file);
     assert!(is_correct_size);
 
-    // imagine with when to use it in a function
+    // we can use it in a function
     fn verify_file_2(file: &ZipFileEntry) -> bool {
         file.name().unwrap() == "my_file.txt"
     }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -392,3 +392,37 @@ fn test_can_create_destination() -> zip::result::ZipResult<()> {
     assert!(dest.path().join("mimetype").exists());
     Ok(())
 }
+
+#[test]
+fn test_zip_file_entry() {
+    use std::io::Write;
+    use zip::CompressionMethod;
+    use zip::ZipArchive;
+    use zip::ZipWriter;
+    use zip::read::ZipFileEntry;
+    use zip::write::SimpleFileOptions;
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    writer.start_file("my_file.txt", options).unwrap();
+    writer.write_all(b"data").unwrap();
+
+    let zip_archive = ZipArchive::new(writer.finish().unwrap()).unwrap();
+
+    let file_number = zip_archive.index_for_name("my_file.txt").unwrap();
+    let file = zip_archive.by_index_data(file_number).unwrap();
+    assert_eq!(file.compression(), CompressionMethod::Stored);
+
+    // imagine with when to use it in a callback
+    let verify_file = |file: &ZipFileEntry| -> bool { file.size() > 2 };
+    let is_correct_size = verify_file(&file);
+    assert!(is_correct_size);
+
+    // imagine with when to use it in a function
+    fn verify_file_2(file: &ZipFileEntry) -> bool {
+        file.name().unwrap() == "my_file.txt"
+    }
+
+    let is_correct_file_name = verify_file_2(&file);
+    assert!(is_correct_file_name);
+}


### PR DESCRIPTION
- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

- Alternative to https://github.com/zip-rs/zip2/pull/860
- Fix https://github.com/zip-rs/zip2/issues/148
- Add same methods to `ZipFile`, `ZipFileSeek`, and the new `ZipFileEntry`