### PR TITLE
feat: add a test on enum size

### DIFF
--- a/src/read/readers.rs
+++ b/src/read/readers.rs
@@ -288,13 +288,23 @@ mod tests {
 
         type R = Cursor<Vec<u8>>;
         let enum_size = size_of::<ZipFileReader<'_, R>>();
-        eprintln!("{enum_size}");
-        eprintln!("{}", size_of::<Take<R>>());
-        eprintln!("{}", size_of::<Crc32Reader<CryptoReader<'_, R>>>());
-        eprintln!(
-            "{}",
-            size_of::<Crc32Reader<Decompressor<BufReader<CryptoReader<'_, R>>>>>()
-        );
+        // Ensure the enum stays small to optimize memory usage, particularly for archives
+        // with many files where many instances may exist simultaneously
         assert!(enum_size <= 32);
+
+        let raw_reader_size = size_of::<Take<&R>>();
+        let stored_reader_size = size_of::<Crc32Reader<CryptoReader<'_, R>>>();
+        let compressed_reader_size =
+            size_of::<Crc32Reader<Decompressor<BufReader<CryptoReader<'_, R>>>>>();
+        let box_size = size_of::<Box<R>>();
+        // eprintln!("enum {enum_size}");
+        // eprintln!("raw: {raw_reader_size}");
+        // eprintln!("stored: {stored_reader_size}");
+        // eprintln!("compressed_reader_size: {compressed_reader_size}");
+        // eprintln!("box: {box_size}");
+        assert!(box_size < enum_size);
+        assert!(raw_reader_size < enum_size);
+        assert!(stored_reader_size > enum_size); // That's why we wrap in a box
+        assert!(compressed_reader_size > enum_size); // That's why we wrap in a box
     }
 }

--- a/src/read/readers.rs
+++ b/src/read/readers.rs
@@ -277,13 +277,13 @@ mod tests {
 
     #[test]
     fn test_size_reader_enum() {
-        use super::ZipFileReader;
         use super::Crc32Reader;
-        use std::io::BufReader;
         use super::CryptoReader;
+        use super::Decompressor;
+        use super::ZipFileReader;
+        use std::io::BufReader;
         use std::io::Cursor;
         use std::io::Take;
-        use super::Decompressor;
         use std::mem::size_of;
 
         type R = Cursor<Vec<u8>>;

--- a/src/read/readers.rs
+++ b/src/read/readers.rs
@@ -272,19 +272,29 @@ pub(crate) fn make_reader<R: Read + ?Sized>(
     ))))
 }
 
-#[test]
-fn test_size_reader_enum() {
-    use std::io::Cursor;
-    use std::mem::size_of;
+#[cfg(test)]
+mod tests {
 
-    type R = Cursor<Vec<u8>>;
-    let enum_size = size_of::<ZipFileReader<'_, R>>();
-    eprintln!("{enum_size}");
-    eprintln!("{}", size_of::<io::Take<R>>());
-    eprintln!("{}", size_of::<Crc32Reader<CryptoReader<'_, R>>>());
-    eprintln!(
-        "{}",
-        size_of::<Crc32Reader<Decompressor<io::BufReader<CryptoReader<'_, R>>>>>()
-    );
-    assert!(enum_size <= 32);
+    #[test]
+    fn test_size_reader_enum() {
+        use super::ZipFileReader;
+        use super::Crc32Reader;
+        use std::io::BufReader;
+        use super::CryptoReader;
+        use std::io::Cursor;
+        use std::io::Take;
+        use super::Decompressor;
+        use std::mem::size_of;
+
+        type R = Cursor<Vec<u8>>;
+        let enum_size = size_of::<ZipFileReader<'_, R>>();
+        eprintln!("{enum_size}");
+        eprintln!("{}", size_of::<Take<R>>());
+        eprintln!("{}", size_of::<Crc32Reader<CryptoReader<'_, R>>>());
+        eprintln!(
+            "{}",
+            size_of::<Crc32Reader<Decompressor<BufReader<CryptoReader<'_, R>>>>>()
+        );
+        assert!(enum_size <= 32);
+    }
 }

--- a/src/read/readers.rs
+++ b/src/read/readers.rs
@@ -271,3 +271,20 @@ pub(crate) fn make_reader<R: Read + ?Sized>(
         should_disable,
     ))))
 }
+
+#[test]
+fn test_size_reader_enum() {
+    use std::io::Cursor;
+    use std::mem::size_of;
+
+    type R = Cursor<Vec<u8>>;
+    let enum_size = size_of::<ZipFileReader<'_, R>>();
+    eprintln!("{enum_size}");
+    eprintln!("{}", size_of::<io::Take<R>>());
+    eprintln!("{}", size_of::<Crc32Reader<CryptoReader<'_, R>>>());
+    eprintln!(
+        "{}",
+        size_of::<Crc32Reader<Decompressor<io::BufReader<CryptoReader<'_, R>>>>>()
+    );
+    assert!(enum_size <= 32);
+}


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
