### PR TITLE
feat: move CustomExtraField to own file

### DIFF
--- a/src/extra_fields/custom_extra_field.rs
+++ b/src/extra_fields/custom_extra_field.rs
@@ -1,0 +1,81 @@
+//! Custom extra field
+
+use crate::result::ZipResult;
+use crate::result::invalid;
+use std::io::Write;
+
+/// A Custom Extra Field
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct CustomExtraField {
+    /// If true, this field will be included in the central directory entry but not the local file header.
+    pub(crate) central_only: bool,
+    /// Header ID of the extra field
+    pub header_id: u16,
+    /// Data of the extra field
+    pub data: Box<[u8]>,
+}
+
+impl CustomExtraField {
+    pub(crate) fn new(central_only: bool, header_id: u16, data: Box<[u8]>) -> Self {
+        Self {
+            central_only,
+            header_id,
+            data,
+        }
+    }
+
+    #[allow(unused)] // used for tests
+    pub(crate) fn new_from_raw(central_only: bool, data: &[u8]) -> ZipResult<Self> {
+        if data.len() < 2 {
+            return Err(invalid!("Cannot build a CustomExtraField: no header_id"));
+        }
+        if data.len() < 4 {
+            return Err(invalid!("Cannot build a CustomExtraField: no size"));
+        }
+        let header_id = u16::from_le_bytes([data[0], data[1]]);
+        let size = u16::from_le_bytes([data[2], data[3]]) as usize;
+        if size > (u16::MAX - 4) as usize {
+            return Err(invalid!("Cannot build a CustomExtraField: size too big"));
+        }
+        let data_rest = &data[4..];
+        if size != data_rest.len() {
+            return Err(invalid!("Cannot build a CustomExtraField: incorrect size"));
+        }
+        Ok(Self {
+            central_only,
+            header_id,
+            data: data_rest.to_vec().into_boxed_slice(),
+        })
+    }
+
+    pub(crate) fn full_size(&self, is_local_header: bool) -> usize {
+        if self.central_only && is_local_header {
+            return 0;
+        }
+        let size = self.data.len();
+        size_of::<u16>() + size_of::<u16>() + size
+    }
+
+    pub(crate) fn write<W: Write>(&self, write: &mut W, is_local_header: bool) -> ZipResult<()> {
+        if self.central_only && is_local_header {
+            return Ok(());
+        }
+        write.write_all(&self.header_id.to_le_bytes())?;
+        let size = self.data.len() as u16;
+        write.write_all(&size.to_le_bytes())?;
+        write.write_all(&self.data)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "_arbitrary")]
+impl arbitrary::Arbitrary<'_> for CustomExtraField {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(CustomExtraField {
+            central_only: u.arbitrary()?,
+            header_id: u.arbitrary()?,
+            data: u.arbitrary()?,
+        })
+    }
+}
+

--- a/src/extra_fields/custom_extra_field.rs
+++ b/src/extra_fields/custom_extra_field.rs
@@ -78,4 +78,3 @@ impl arbitrary::Arbitrary<'_> for CustomExtraField {
         })
     }
 }
-

--- a/src/extra_fields/extra_field.rs
+++ b/src/extra_fields/extra_field.rs
@@ -198,7 +198,7 @@ impl ExtraField {
             }
             ExtraField::UnicodeComment(unicode_comment) => unicode_comment.full_size(),
             ExtraField::UnicodePath(unicode_path) => unicode_path.full_size(),
-            ExtraField::Custom(custom) => custom.len_with_header(is_local_header),
+            ExtraField::Custom(custom) => custom.full_size(is_local_header),
             ExtraField::DataStreamAlignment(data_stream_alignment) => {
                 data_stream_alignment.full_size(is_local_header)
             }

--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -24,6 +24,7 @@ pub use zipinfo_utf8::UnicodeExtraField;
 
 // re-export
 pub use crate::format::extra_fields::EXTRA_FIELD_MAPPING;
+use crate::format::extra_fields::ExtraFieldId;
 
 /// Marker trait to denote the place where this extra field has been stored.
 pub trait ExtraFieldVersion {}
@@ -48,20 +49,20 @@ impl ExtraFieldVersion for CentralHeaderVersion {}
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum UsedExtraField {
     /// ZIP64 extended information extra field
-    Zip64ExtendedInfo = 0x0001,
+    Zip64ExtendedInfo = ExtraFieldId::Zip64ExtendedInfo.as_u16(),
     /// NTFS
-    Ntfs = 0x000a,
+    Ntfs = ExtraFieldId::Ntfs.as_u16(),
     /// extended timestamp
     /// from <https://libzip.org/specifications/extrafld.txt>
-    ExtendedTimestamp = 0x5455,
+    ExtendedTimestamp = ExtraFieldId::ExtendedTimestamp.as_u16(),
     /// Info-ZIP Unicode Comment Extra Field
-    UnicodeComment = 0x6375,
+    UnicodeComment = ExtraFieldId::UnicodeComment.as_u16(),
     /// Info-ZIP Unicode Path Extra Field
-    UnicodePath = 0x7075,
+    UnicodePath = ExtraFieldId::UnicodePath.as_u16(),
     /// AE-x encryption structure
-    AeXEncryption = 0x9901,
+    AeXEncryption = ExtraFieldId::AeXEncryption.as_u16(),
     /// Data Stream Alignment (Apache Commons-Compress)
-    DataStreamAlignment = 0xa11e,
+    DataStreamAlignment = ExtraFieldId::DataStreamAlignment.as_u16(),
 }
 
 impl UsedExtraField {

--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -1,9 +1,6 @@
 //! Types for extra fields
 
-use crate::result::ZipResult;
-use crate::result::invalid;
 use core::fmt::Display;
-use std::io::Write;
 
 mod aex_encryption;
 mod data_stream_alignment;
@@ -11,9 +8,10 @@ mod extended_timestamp;
 mod extra_field;
 mod ntfs;
 mod zip64_extended_information;
+mod custom_extra_field;
 mod zipinfo_utf8;
 
-// re-export
+// re-export extra fields
 #[cfg(feature = "aes-crypto")]
 pub use aex_encryption::AexEncryption;
 pub use data_stream_alignment::DataStreamAlignment;
@@ -22,6 +20,10 @@ pub use extra_field::{ExtraField, ExtraFields};
 pub use ntfs::Ntfs;
 pub use zip64_extended_information::{Zip64ExtendedInformation, Zip64Sizes};
 pub use zipinfo_utf8::UnicodeExtraField;
+pub use custom_extra_field::CustomExtraField;
+
+// re-export
+pub use crate::format::extra_fields::EXTRA_FIELD_MAPPING;
 
 /// Marker trait to denote the place where this extra field has been stored.
 pub trait ExtraFieldVersion {}
@@ -110,144 +112,5 @@ impl TryFrom<u16> for UsedExtraField {
             UsedExtraField::DataStreamAlignment,
             UsedExtraField::AeXEncryption,
         )
-    }
-}
-
-/// Known Extra fields (PKWARE and Third party) mappings, sorted
-pub const EXTRA_FIELD_MAPPING: [u16; 59] = [
-    UsedExtraField::Zip64ExtendedInfo.as_u16(),
-    0x0007, // AV Info
-    0x0008, // Reserved for extended language encoding data (PFS)
-    0x0009, // OS/2
-    UsedExtraField::Ntfs.as_u16(),
-    0x000c, // OpenVMS
-    0x000d, // UNIX
-    0x000e, // Reserved for file stream and fork descriptors
-    0x000f, // Patch Descriptor
-    0x0014, // PKCS#7 Store for X.509 Certificates
-    0x0015, // X.509 Certificate ID and Signature for individual file
-    0x0016, // X.509 Certificate ID for Central Directory
-    0x0017, // Strong Encryption Header
-    0x0018, // Record Management Controls
-    0x0019, // PKCS#7 Encryption Recipient Certificate List
-    0x0020, // Reserved for Timestamp record
-    0x0021, // Policy Decryption Key Record
-    0x0022, // Smartcrypt Key Provider Record
-    0x0023, // Smartcrypt Policy Key Data Record
-    0x0065, // IBM S/390 (Z390), AS/400 (I400) attributes - uncompressed
-    0x0066, // Reserved for IBM S/390 (Z390), AS/400 (I400) attributes - compressed
-    // Third party mappings commonly used
-    0x07c8, // Macintosh
-    0x1986, // Pixar USD header ID
-    0x2605, // ZipIt Macintosh
-    0x2705, // ZipIt Macintosh 1.3.5+
-    0x2805, // ZipIt Macintosh 1.3.5+
-    0x334d, // Info-ZIP Macintosh
-    0x4154, // Tandem
-    0x4341, // Acorn/SparkFS
-    0x4453, // Windows NT security descriptor (binary ACL)
-    0x4690, // POSZIP 4690 (reserved)
-    0x4704, // VM/CMS
-    0x470f, // MVS
-    0x4854, // THEOS (old?)
-    0x4b46, // FWKCS MD5
-    0x4c41, // OS/2 access control list (text ACL)
-    0x4d49, // Info-ZIP OpenVMS
-    0x4d63, // Macintosh Smartzip (??)
-    0x4f4c, // Xceed original location extra field
-    0x5356, // AOS/VS (ACL)
-    UsedExtraField::ExtendedTimestamp.as_u16(),
-    0x554e, // Xceed unicode extra field
-    0x5855, // Info-ZIP UNIX (original, also OS/2, NT, etc)
-    UsedExtraField::UnicodeComment.as_u16(),
-    0x6542, // BeOS/BeBox
-    0x6854, // THEOS
-    UsedExtraField::UnicodePath.as_u16(),
-    0x7441, // AtheOS/Syllable
-    0x756e, // ASi UNIX
-    0x7855, // Info-ZIP UNIX (new)
-    0x7875, // Info-ZIP UNIX (newer UID/GID)
-    UsedExtraField::AeXEncryption.as_u16(),
-    0x9902, // unknown
-    UsedExtraField::DataStreamAlignment.as_u16(),
-    0xa220, // Microsoft Open Packaging Growth Hint
-    0xcafe, // Java JAR file Extra Field Header ID
-    0xd935, // Android ZIP Alignment Extra Field
-    0xe57a, // Korean ZIP code page info
-    0xfd4a, // SMS/QDOS
-];
-
-/// A Custom Extra Field
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct CustomExtraField {
-    /// If true, this field will be included in the central directory entry but not the local file header.
-    pub(crate) central_only: bool,
-    /// Header ID of the extra field
-    pub header_id: u16,
-    /// Data of the extra field
-    pub data: Box<[u8]>,
-}
-
-impl CustomExtraField {
-    pub(crate) fn new(central_only: bool, header_id: u16, data: Box<[u8]>) -> Self {
-        Self {
-            central_only,
-            header_id,
-            data,
-        }
-    }
-
-    #[allow(unused)] // used for tests
-    pub(crate) fn new_from_raw(central_only: bool, data: &[u8]) -> ZipResult<Self> {
-        if data.len() < 2 {
-            return Err(invalid!("Cannot build a CustomExtraField: no header_id"));
-        }
-        if data.len() < 4 {
-            return Err(invalid!("Cannot build a CustomExtraField: no size"));
-        }
-        let header_id = u16::from_le_bytes([data[0], data[1]]);
-        let size = u16::from_le_bytes([data[2], data[3]]) as usize;
-        if size > (u16::MAX - 4) as usize {
-            return Err(invalid!("Cannot build a CustomExtraField: size too big"));
-        }
-        let data_rest = &data[4..];
-        if size != data_rest.len() {
-            return Err(invalid!("Cannot build a CustomExtraField: incorrect size"));
-        }
-        Ok(Self {
-            central_only,
-            header_id,
-            data: data_rest.to_vec().into_boxed_slice(),
-        })
-    }
-
-    pub(crate) fn len_with_header(&self, is_local_header: bool) -> usize {
-        if self.central_only && is_local_header {
-            return 0;
-        }
-        let size = self.data.len();
-        size_of::<u16>() + size_of::<u16>() + size
-    }
-
-    pub(crate) fn write<W: Write>(&self, write: &mut W, is_local_header: bool) -> ZipResult<()> {
-        if self.central_only && is_local_header {
-            return Ok(());
-        }
-        write.write_all(&self.header_id.to_le_bytes())?;
-        let size = self.data.len() as u16;
-        write.write_all(&size.to_le_bytes())?;
-        write.write_all(&self.data)?;
-        Ok(())
-    }
-}
-
-#[cfg(feature = "_arbitrary")]
-impl arbitrary::Arbitrary<'_> for CustomExtraField {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        Ok(CustomExtraField {
-            central_only: u.arbitrary()?,
-            header_id: u.arbitrary()?,
-            data: u.arbitrary()?,
-        })
     }
 }

--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -3,24 +3,24 @@
 use core::fmt::Display;
 
 mod aex_encryption;
+mod custom_extra_field;
 mod data_stream_alignment;
 mod extended_timestamp;
 mod extra_field;
 mod ntfs;
 mod zip64_extended_information;
-mod custom_extra_field;
 mod zipinfo_utf8;
 
 // re-export extra fields
 #[cfg(feature = "aes-crypto")]
 pub use aex_encryption::AexEncryption;
+pub use custom_extra_field::CustomExtraField;
 pub use data_stream_alignment::DataStreamAlignment;
 pub use extended_timestamp::ExtendedTimestamp;
 pub use extra_field::{ExtraField, ExtraFields};
 pub use ntfs::Ntfs;
 pub use zip64_extended_information::{Zip64ExtendedInformation, Zip64Sizes};
 pub use zipinfo_utf8::UnicodeExtraField;
-pub use custom_extra_field::CustomExtraField;
 
 // re-export
 pub use crate::format::extra_fields::EXTRA_FIELD_MAPPING;

--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -47,6 +47,7 @@ impl ExtraFieldVersion for CentralHeaderVersion {}
 /// public extra-field data structures.
 #[repr(u16)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub(crate) enum UsedExtraField {
     /// ZIP64 extended information extra field
     Zip64ExtendedInfo = ExtraFieldId::Zip64ExtendedInfo.as_u16(),

--- a/src/format/extra_fields.rs
+++ b/src/format/extra_fields.rs
@@ -1,5 +1,7 @@
 //! Extra fields
 
+use crate::extra_fields::UsedExtraField;
+
 /// Known Extra fields (PKWARE and Third party) mappings, sorted
 pub const EXTRA_FIELD_MAPPING: [u16; 59] = [
     UsedExtraField::Zip64ExtendedInfo.as_u16(),

--- a/src/format/extra_fields.rs
+++ b/src/format/extra_fields.rs
@@ -1,67 +1,138 @@
 //! Extra fields
 
-use crate::extra_fields::UsedExtraField;
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(unused)]
+pub enum ExtraFieldId {
+    Zip64ExtendedInfo = 0x0001,
+    AvInfo = 0x0007, // AV Info
+    ReservedExtendedLanguageEncoding = 0x0008, // Reserved for extended language encoding data (PFS)
+    Os2 = 0x0009, // OS/2
+    Ntfs = 0x000a,
+    OpenVms = 0x000c, // OpenVMS
+    Unix = 0x000d, // UNIX
+    ReservedFileStreamAndForkDescriptors = 0x000e, // Reserved for file stream and fork descriptors
+    PatchDescriptor = 0x000f, // Patch Descriptor
+    Pkcs7StoreForX509Certificates = 0x0014, // PKCS#7 Store for X.509 Certificates
+    X509CertificateIdAndSignature = 0x0015, // X.509 Certificate ID and Signature for individual file
+    X509CertificateIdCentralDirectory = 0x0016, // X.509 Certificate ID for Central Directory
+    StrongEncryptionHeader = 0x0017, // Strong Encryption Header
+    RecordManagementControls = 0x0018, // Record Management Controls
+    Pkcs7EncryptionRecipientCertificateList = 0x0019, // PKCS#7 Encryption Recipient Certificate List
+    ReservedTimestampRecord = 0x0020, // Reserved for Timestamp record
+    PolicyDecryptionKeyRecord = 0x0021, // Policy Decryption Key Record
+    SmartcryptKeyProviderRecord = 0x0022, // Smartcrypt Key Provider Record
+    SmartcryptPolicyKeyDataRecord = 0x0023, // Smartcrypt Policy Key Data Record
+    IbmS390As400Attributes = 0x0065, // IBM S/390 (Z390), AS/400 (I400) attributes - uncompressed
+    ReservedIbmS390As400AttributesCompressed = 0x0066, // Reserved for IBM S/390 (Z390), AS/400 (I400) attributes - compressed
+    // Third party mappings commonly used
+    Macintosh = 0x07c8, // Macintosh
+    PixarUsdHeader = 0x1986, // Pixar USD header ID
+    ZipItMacintosh = 0x2605, // ZipIt Macintosh
+    ZipItMacintosh135Plus = 0x2705, // ZipIt Macintosh 1.3.5+
+    ZipItMacintosh135PlusAlt = 0x2805, // ZipIt Macintosh 1.3.5+
+    InfoZipMacintosh = 0x334d, // Info-ZIP Macintosh
+    Tandem = 0x4154, // Tandem
+    AcornSparkFs = 0x4341, // Acorn/SparkFS
+    WindowsNtSecurityDescriptor = 0x4453, // Windows NT security descriptor (binary ACL)
+    Poszip4690 = 0x4690, // POSZIP 4690 (reserved)
+    VmCms = 0x4704, // VM/CMS
+    Mvs = 0x470f, // MVS
+    TheosOld = 0x4854, // THEOS (old?)
+    FwkcsMd5 = 0x4b46, // FWKCS MD5
+    Os2AccessControlList = 0x4c41, // OS/2 access control list (text ACL)
+    InfoZipOpenVms = 0x4d49, // Info-ZIP OpenVMS
+    MacintoshSmartzip = 0x4d63, // Macintosh Smartzip (??)
+    XceedOriginalLocation = 0x4f4c, // Xceed original location extra field
+    AosVsAcl = 0x5356, // AOS/VS (ACL)
+    ExtendedTimestamp = 0x5455,
+    XceedUnicode = 0x554e, // Xceed unicode extra field
+    InfoZipUnixOriginal = 0x5855, // Info-ZIP UNIX (original, also OS/2, NT, etc)
+    UnicodeComment = 0x6375,
+    BeOsBeBox = 0x6542, // BeOS/BeBox
+    Theos = 0x6854, // THEOS
+    UnicodePath = 0x7075,
+    AtheosSyllable = 0x7441, // AtheOS/Syllable
+    AsiUnix = 0x756e, // ASi UNIX
+    InfoZipUnixNew = 0x7855, // Info-ZIP UNIX (new)
+    InfoZipUnixNewerUidGid = 0x7875, // Info-ZIP UNIX (newer UID/GID)
+    AeXEncryption = 0x9901,
+    Unknown9902 = 0x9902, // unknown
+    DataStreamAlignment = 0xa11e,
+    MicrosoftOpenPackagingGrowthHint = 0xa220, // Microsoft Open Packaging Growth Hint
+    JavaJar = 0xcafe, // Java JAR file Extra Field Header ID
+    AndroidZipAlignment = 0xd935, // Android ZIP Alignment Extra Field
+    KoreanZipCodePageInfo = 0xe57a, // Korean ZIP code page info
+    SmsQdos = 0xfd4a, // SMS/QDOS
+}
+
+impl ExtraFieldId {
+    pub const fn as_u16(self) -> u16 {
+        self as u16
+    }
+}
 
 /// Known Extra fields (PKWARE and Third party) mappings, sorted
 pub const EXTRA_FIELD_MAPPING: [u16; 59] = [
-    UsedExtraField::Zip64ExtendedInfo.as_u16(),
-    0x0007, // AV Info
-    0x0008, // Reserved for extended language encoding data (PFS)
-    0x0009, // OS/2
-    UsedExtraField::Ntfs.as_u16(),
-    0x000c, // OpenVMS
-    0x000d, // UNIX
-    0x000e, // Reserved for file stream and fork descriptors
-    0x000f, // Patch Descriptor
-    0x0014, // PKCS#7 Store for X.509 Certificates
-    0x0015, // X.509 Certificate ID and Signature for individual file
-    0x0016, // X.509 Certificate ID for Central Directory
-    0x0017, // Strong Encryption Header
-    0x0018, // Record Management Controls
-    0x0019, // PKCS#7 Encryption Recipient Certificate List
-    0x0020, // Reserved for Timestamp record
-    0x0021, // Policy Decryption Key Record
-    0x0022, // Smartcrypt Key Provider Record
-    0x0023, // Smartcrypt Policy Key Data Record
-    0x0065, // IBM S/390 (Z390), AS/400 (I400) attributes - uncompressed
-    0x0066, // Reserved for IBM S/390 (Z390), AS/400 (I400) attributes - compressed
+    ExtraFieldId::Zip64ExtendedInfo.as_u16(),
+    ExtraFieldId::AvInfo.as_u16(),
+    ExtraFieldId::ReservedExtendedLanguageEncoding.as_u16(),
+    ExtraFieldId::Os2.as_u16(),
+    ExtraFieldId::Ntfs.as_u16(),
+    ExtraFieldId::OpenVms.as_u16(),
+    ExtraFieldId::Unix.as_u16(),
+    ExtraFieldId::ReservedFileStreamAndForkDescriptors.as_u16(),
+    ExtraFieldId::PatchDescriptor.as_u16(),
+    ExtraFieldId::Pkcs7StoreForX509Certificates.as_u16(),
+    ExtraFieldId::X509CertificateIdAndSignature.as_u16(),
+    ExtraFieldId::X509CertificateIdCentralDirectory.as_u16(),
+    ExtraFieldId::StrongEncryptionHeader.as_u16(),
+    ExtraFieldId::RecordManagementControls.as_u16(),
+    ExtraFieldId::Pkcs7EncryptionRecipientCertificateList.as_u16(),
+    ExtraFieldId::ReservedTimestampRecord.as_u16(),
+    ExtraFieldId::PolicyDecryptionKeyRecord.as_u16(),
+    ExtraFieldId::SmartcryptKeyProviderRecord.as_u16(),
+    ExtraFieldId::SmartcryptPolicyKeyDataRecord.as_u16(),
+    ExtraFieldId::IbmS390As400Attributes.as_u16(),
+    ExtraFieldId::ReservedIbmS390As400AttributesCompressed.as_u16(),
     // Third party mappings commonly used
-    0x07c8, // Macintosh
-    0x1986, // Pixar USD header ID
-    0x2605, // ZipIt Macintosh
-    0x2705, // ZipIt Macintosh 1.3.5+
-    0x2805, // ZipIt Macintosh 1.3.5+
-    0x334d, // Info-ZIP Macintosh
-    0x4154, // Tandem
-    0x4341, // Acorn/SparkFS
-    0x4453, // Windows NT security descriptor (binary ACL)
-    0x4690, // POSZIP 4690 (reserved)
-    0x4704, // VM/CMS
-    0x470f, // MVS
-    0x4854, // THEOS (old?)
-    0x4b46, // FWKCS MD5
-    0x4c41, // OS/2 access control list (text ACL)
-    0x4d49, // Info-ZIP OpenVMS
-    0x4d63, // Macintosh Smartzip (??)
-    0x4f4c, // Xceed original location extra field
-    0x5356, // AOS/VS (ACL)
-    UsedExtraField::ExtendedTimestamp.as_u16(),
-    0x554e, // Xceed unicode extra field
-    0x5855, // Info-ZIP UNIX (original, also OS/2, NT, etc)
-    UsedExtraField::UnicodeComment.as_u16(),
-    0x6542, // BeOS/BeBox
-    0x6854, // THEOS
-    UsedExtraField::UnicodePath.as_u16(),
-    0x7441, // AtheOS/Syllable
-    0x756e, // ASi UNIX
-    0x7855, // Info-ZIP UNIX (new)
-    0x7875, // Info-ZIP UNIX (newer UID/GID)
-    UsedExtraField::AeXEncryption.as_u16(),
-    0x9902, // unknown
-    UsedExtraField::DataStreamAlignment.as_u16(),
-    0xa220, // Microsoft Open Packaging Growth Hint
-    0xcafe, // Java JAR file Extra Field Header ID
-    0xd935, // Android ZIP Alignment Extra Field
-    0xe57a, // Korean ZIP code page info
-    0xfd4a, // SMS/QDOS
+    ExtraFieldId::Macintosh.as_u16(),
+    ExtraFieldId::PixarUsdHeader.as_u16(),
+    ExtraFieldId::ZipItMacintosh.as_u16(),
+    ExtraFieldId::ZipItMacintosh135Plus.as_u16(),
+    ExtraFieldId::ZipItMacintosh135PlusAlt.as_u16(),
+    ExtraFieldId::InfoZipMacintosh.as_u16(),
+    ExtraFieldId::Tandem.as_u16(),
+    ExtraFieldId::AcornSparkFs.as_u16(),
+    ExtraFieldId::WindowsNtSecurityDescriptor.as_u16(),
+    ExtraFieldId::Poszip4690.as_u16(),
+    ExtraFieldId::VmCms.as_u16(),
+    ExtraFieldId::Mvs.as_u16(),
+    ExtraFieldId::TheosOld.as_u16(),
+    ExtraFieldId::FwkcsMd5.as_u16(),
+    ExtraFieldId::Os2AccessControlList.as_u16(),
+    ExtraFieldId::InfoZipOpenVms.as_u16(),
+    ExtraFieldId::MacintoshSmartzip.as_u16(),
+    ExtraFieldId::XceedOriginalLocation.as_u16(),
+    ExtraFieldId::AosVsAcl.as_u16(),
+    ExtraFieldId::ExtendedTimestamp.as_u16(),
+    ExtraFieldId::XceedUnicode.as_u16(),
+    ExtraFieldId::InfoZipUnixOriginal.as_u16(),
+    ExtraFieldId::UnicodeComment.as_u16(),
+    ExtraFieldId::BeOsBeBox.as_u16(),
+    ExtraFieldId::Theos.as_u16(),
+    ExtraFieldId::UnicodePath.as_u16(),
+    ExtraFieldId::AtheosSyllable.as_u16(),
+    ExtraFieldId::AsiUnix.as_u16(),
+    ExtraFieldId::InfoZipUnixNew.as_u16(),
+    ExtraFieldId::InfoZipUnixNewerUidGid.as_u16(),
+    ExtraFieldId::AeXEncryption.as_u16(),
+    ExtraFieldId::Unknown9902.as_u16(),
+    ExtraFieldId::DataStreamAlignment.as_u16(),
+    ExtraFieldId::MicrosoftOpenPackagingGrowthHint.as_u16(),
+    ExtraFieldId::JavaJar.as_u16(),
+    ExtraFieldId::AndroidZipAlignment.as_u16(),
+    ExtraFieldId::KoreanZipCodePageInfo.as_u16(),
+    ExtraFieldId::SmsQdos.as_u16(),
 ];
+

--- a/src/format/extra_fields.rs
+++ b/src/format/extra_fields.rs
@@ -1,0 +1,65 @@
+//! Extra fields
+
+/// Known Extra fields (PKWARE and Third party) mappings, sorted
+pub const EXTRA_FIELD_MAPPING: [u16; 59] = [
+    UsedExtraField::Zip64ExtendedInfo.as_u16(),
+    0x0007, // AV Info
+    0x0008, // Reserved for extended language encoding data (PFS)
+    0x0009, // OS/2
+    UsedExtraField::Ntfs.as_u16(),
+    0x000c, // OpenVMS
+    0x000d, // UNIX
+    0x000e, // Reserved for file stream and fork descriptors
+    0x000f, // Patch Descriptor
+    0x0014, // PKCS#7 Store for X.509 Certificates
+    0x0015, // X.509 Certificate ID and Signature for individual file
+    0x0016, // X.509 Certificate ID for Central Directory
+    0x0017, // Strong Encryption Header
+    0x0018, // Record Management Controls
+    0x0019, // PKCS#7 Encryption Recipient Certificate List
+    0x0020, // Reserved for Timestamp record
+    0x0021, // Policy Decryption Key Record
+    0x0022, // Smartcrypt Key Provider Record
+    0x0023, // Smartcrypt Policy Key Data Record
+    0x0065, // IBM S/390 (Z390), AS/400 (I400) attributes - uncompressed
+    0x0066, // Reserved for IBM S/390 (Z390), AS/400 (I400) attributes - compressed
+    // Third party mappings commonly used
+    0x07c8, // Macintosh
+    0x1986, // Pixar USD header ID
+    0x2605, // ZipIt Macintosh
+    0x2705, // ZipIt Macintosh 1.3.5+
+    0x2805, // ZipIt Macintosh 1.3.5+
+    0x334d, // Info-ZIP Macintosh
+    0x4154, // Tandem
+    0x4341, // Acorn/SparkFS
+    0x4453, // Windows NT security descriptor (binary ACL)
+    0x4690, // POSZIP 4690 (reserved)
+    0x4704, // VM/CMS
+    0x470f, // MVS
+    0x4854, // THEOS (old?)
+    0x4b46, // FWKCS MD5
+    0x4c41, // OS/2 access control list (text ACL)
+    0x4d49, // Info-ZIP OpenVMS
+    0x4d63, // Macintosh Smartzip (??)
+    0x4f4c, // Xceed original location extra field
+    0x5356, // AOS/VS (ACL)
+    UsedExtraField::ExtendedTimestamp.as_u16(),
+    0x554e, // Xceed unicode extra field
+    0x5855, // Info-ZIP UNIX (original, also OS/2, NT, etc)
+    UsedExtraField::UnicodeComment.as_u16(),
+    0x6542, // BeOS/BeBox
+    0x6854, // THEOS
+    UsedExtraField::UnicodePath.as_u16(),
+    0x7441, // AtheOS/Syllable
+    0x756e, // ASi UNIX
+    0x7855, // Info-ZIP UNIX (new)
+    0x7875, // Info-ZIP UNIX (newer UID/GID)
+    UsedExtraField::AeXEncryption.as_u16(),
+    0x9902, // unknown
+    UsedExtraField::DataStreamAlignment.as_u16(),
+    0xa220, // Microsoft Open Packaging Growth Hint
+    0xcafe, // Java JAR file Extra Field Header ID
+    0xd935, // Android ZIP Alignment Extra Field
+    0xe57a, // Korean ZIP code page info
+    0xfd4a, // SMS/QDOS
+];

--- a/src/format/extra_fields.rs
+++ b/src/format/extra_fields.rs
@@ -5,65 +5,65 @@
 #[allow(unused)]
 pub enum ExtraFieldId {
     Zip64ExtendedInfo = 0x0001,
-    AvInfo = 0x0007, // AV Info
+    AvInfo = 0x0007,                           // AV Info
     ReservedExtendedLanguageEncoding = 0x0008, // Reserved for extended language encoding data (PFS)
-    Os2 = 0x0009, // OS/2
+    Os2 = 0x0009,                              // OS/2
     Ntfs = 0x000a,
-    OpenVms = 0x000c, // OpenVMS
-    Unix = 0x000d, // UNIX
+    OpenVms = 0x000c,                                  // OpenVMS
+    Unix = 0x000d,                                     // UNIX
     ReservedFileStreamAndForkDescriptors = 0x000e, // Reserved for file stream and fork descriptors
-    PatchDescriptor = 0x000f, // Patch Descriptor
-    Pkcs7StoreForX509Certificates = 0x0014, // PKCS#7 Store for X.509 Certificates
+    PatchDescriptor = 0x000f,                      // Patch Descriptor
+    Pkcs7StoreForX509Certificates = 0x0014,        // PKCS#7 Store for X.509 Certificates
     X509CertificateIdAndSignature = 0x0015, // X.509 Certificate ID and Signature for individual file
     X509CertificateIdCentralDirectory = 0x0016, // X.509 Certificate ID for Central Directory
-    StrongEncryptionHeader = 0x0017, // Strong Encryption Header
-    RecordManagementControls = 0x0018, // Record Management Controls
+    StrongEncryptionHeader = 0x0017,        // Strong Encryption Header
+    RecordManagementControls = 0x0018,      // Record Management Controls
     Pkcs7EncryptionRecipientCertificateList = 0x0019, // PKCS#7 Encryption Recipient Certificate List
-    ReservedTimestampRecord = 0x0020, // Reserved for Timestamp record
-    PolicyDecryptionKeyRecord = 0x0021, // Policy Decryption Key Record
-    SmartcryptKeyProviderRecord = 0x0022, // Smartcrypt Key Provider Record
-    SmartcryptPolicyKeyDataRecord = 0x0023, // Smartcrypt Policy Key Data Record
+    ReservedTimestampRecord = 0x0020,                 // Reserved for Timestamp record
+    PolicyDecryptionKeyRecord = 0x0021,               // Policy Decryption Key Record
+    SmartcryptKeyProviderRecord = 0x0022,             // Smartcrypt Key Provider Record
+    SmartcryptPolicyKeyDataRecord = 0x0023,           // Smartcrypt Policy Key Data Record
     IbmS390As400Attributes = 0x0065, // IBM S/390 (Z390), AS/400 (I400) attributes - uncompressed
     ReservedIbmS390As400AttributesCompressed = 0x0066, // Reserved for IBM S/390 (Z390), AS/400 (I400) attributes - compressed
     // Third party mappings commonly used
-    Macintosh = 0x07c8, // Macintosh
-    PixarUsdHeader = 0x1986, // Pixar USD header ID
-    ZipItMacintosh = 0x2605, // ZipIt Macintosh
-    ZipItMacintosh135Plus = 0x2705, // ZipIt Macintosh 1.3.5+
-    ZipItMacintosh135PlusAlt = 0x2805, // ZipIt Macintosh 1.3.5+
-    InfoZipMacintosh = 0x334d, // Info-ZIP Macintosh
-    Tandem = 0x4154, // Tandem
-    AcornSparkFs = 0x4341, // Acorn/SparkFS
+    Macintosh = 0x07c8,                   // Macintosh
+    PixarUsdHeader = 0x1986,              // Pixar USD header ID
+    ZipItMacintosh = 0x2605,              // ZipIt Macintosh
+    ZipItMacintosh135Plus = 0x2705,       // ZipIt Macintosh 1.3.5+
+    ZipItMacintosh135PlusAlt = 0x2805,    // ZipIt Macintosh 1.3.5+
+    InfoZipMacintosh = 0x334d,            // Info-ZIP Macintosh
+    Tandem = 0x4154,                      // Tandem
+    AcornSparkFs = 0x4341,                // Acorn/SparkFS
     WindowsNtSecurityDescriptor = 0x4453, // Windows NT security descriptor (binary ACL)
-    Poszip4690 = 0x4690, // POSZIP 4690 (reserved)
-    VmCms = 0x4704, // VM/CMS
-    Mvs = 0x470f, // MVS
-    TheosOld = 0x4854, // THEOS (old?)
-    FwkcsMd5 = 0x4b46, // FWKCS MD5
-    Os2AccessControlList = 0x4c41, // OS/2 access control list (text ACL)
-    InfoZipOpenVms = 0x4d49, // Info-ZIP OpenVMS
-    MacintoshSmartzip = 0x4d63, // Macintosh Smartzip (??)
-    XceedOriginalLocation = 0x4f4c, // Xceed original location extra field
-    AosVsAcl = 0x5356, // AOS/VS (ACL)
+    Poszip4690 = 0x4690,                  // POSZIP 4690 (reserved)
+    VmCms = 0x4704,                       // VM/CMS
+    Mvs = 0x470f,                         // MVS
+    TheosOld = 0x4854,                    // THEOS (old?)
+    FwkcsMd5 = 0x4b46,                    // FWKCS MD5
+    Os2AccessControlList = 0x4c41,        // OS/2 access control list (text ACL)
+    InfoZipOpenVms = 0x4d49,              // Info-ZIP OpenVMS
+    MacintoshSmartzip = 0x4d63,           // Macintosh Smartzip (??)
+    XceedOriginalLocation = 0x4f4c,       // Xceed original location extra field
+    AosVsAcl = 0x5356,                    // AOS/VS (ACL)
     ExtendedTimestamp = 0x5455,
-    XceedUnicode = 0x554e, // Xceed unicode extra field
+    XceedUnicode = 0x554e,        // Xceed unicode extra field
     InfoZipUnixOriginal = 0x5855, // Info-ZIP UNIX (original, also OS/2, NT, etc)
     UnicodeComment = 0x6375,
     BeOsBeBox = 0x6542, // BeOS/BeBox
-    Theos = 0x6854, // THEOS
+    Theos = 0x6854,     // THEOS
     UnicodePath = 0x7075,
-    AtheosSyllable = 0x7441, // AtheOS/Syllable
-    AsiUnix = 0x756e, // ASi UNIX
-    InfoZipUnixNew = 0x7855, // Info-ZIP UNIX (new)
+    AtheosSyllable = 0x7441,         // AtheOS/Syllable
+    AsiUnix = 0x756e,                // ASi UNIX
+    InfoZipUnixNew = 0x7855,         // Info-ZIP UNIX (new)
     InfoZipUnixNewerUidGid = 0x7875, // Info-ZIP UNIX (newer UID/GID)
     AeXEncryption = 0x9901,
     Unknown9902 = 0x9902, // unknown
     DataStreamAlignment = 0xa11e,
     MicrosoftOpenPackagingGrowthHint = 0xa220, // Microsoft Open Packaging Growth Hint
-    JavaJar = 0xcafe, // Java JAR file Extra Field Header ID
-    AndroidZipAlignment = 0xd935, // Android ZIP Alignment Extra Field
-    KoreanZipCodePageInfo = 0xe57a, // Korean ZIP code page info
-    SmsQdos = 0xfd4a, // SMS/QDOS
+    JavaJar = 0xcafe,                          // Java JAR file Extra Field Header ID
+    AndroidZipAlignment = 0xd935,              // Android ZIP Alignment Extra Field
+    KoreanZipCodePageInfo = 0xe57a,            // Korean ZIP code page info
+    SmsQdos = 0xfd4a,                          // SMS/QDOS
 }
 
 impl ExtraFieldId {
@@ -135,4 +135,3 @@ pub const EXTRA_FIELD_MAPPING: [u16; 59] = [
     ExtraFieldId::KoreanZipCodePageInfo.as_u16(),
     ExtraFieldId::SmsQdos.as_u16(),
 ];
-

--- a/src/format/extra_fields.rs
+++ b/src/format/extra_fields.rs
@@ -3,6 +3,7 @@
 #[repr(u16)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(unused)]
+#[non_exhaustive]
 pub enum ExtraFieldId {
     Zip64ExtendedInfo = 0x0001,
     AvInfo = 0x0007,                           // AV Info

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod aes;
 pub(crate) mod blocks;
 pub(crate) mod flags;
 pub(crate) mod functions;
+pub(crate) mod extra_fields;
 pub(crate) mod magic;
 
 pub(crate) mod ffi {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -2,9 +2,9 @@
 
 pub(crate) mod aes;
 pub(crate) mod blocks;
+pub(crate) mod extra_fields;
 pub(crate) mod flags;
 pub(crate) mod functions;
-pub(crate) mod extra_fields;
 pub(crate) mod magic;
 
 pub(crate) mod ffi {

--- a/src/write/options.rs
+++ b/src/write/options.rs
@@ -188,11 +188,7 @@ impl ExtendedFileOptions {
     ) -> ZipResult<()> {
         let data = data.as_ref();
         let len = data.len() + 4;
-        let extra_fields_len: usize = self
-            .extra_fields
-            .iter()
-            .map(|x| x.len_with_header(false))
-            .sum();
+        let extra_fields_len: usize = self.extra_fields.iter().map(|x| x.full_size(false)).sum();
         if extra_fields_len + len > u16::MAX as usize {
             Err(invalid!("Extra data field would be longer than allowed"))
         } else {


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
