### PR TITLE
refactor: access `crate::format` with `zip::unstable::format`

### DIFF
--- a/src/format/aes.rs
+++ b/src/format/aes.rs
@@ -9,7 +9,9 @@ use core::fmt::Display;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u16)]
 pub enum AesVendorVersion {
+    /// Ae1 version
     Ae1 = 0x0001,
+    /// Ae2 version
     Ae2 = 0x0002,
 }
 

--- a/src/format/aes.rs
+++ b/src/format/aes.rs
@@ -24,12 +24,14 @@ impl AesVendorVersion {
 
     /// Returns `true` if the data is encrypted using AE2.
     #[cfg(feature = "aes-crypto")]
+    #[must_use]
     pub const fn is_ae2_encrypted(&self) -> bool {
         matches!(self, AesVendorVersion::Ae2)
     }
 
     /// `false` since the feature `aes-crypto` is not enabled
     #[cfg(not(feature = "aes-crypto"))]
+    #[must_use]
     pub const fn is_ae2_encrypted(&self) -> bool {
         false
     }

--- a/src/format/blocks.rs
+++ b/src/format/blocks.rs
@@ -147,7 +147,8 @@ macro_rules! to_and_from_le {
 
 #[derive(Copy, Clone, Debug)]
 #[repr(packed, C)]
-pub(crate) struct ZipCentralEntryBlock {
+#[allow(missing_docs)]
+pub struct ZipCentralEntryBlock {
     pub version_made_by: u16,
     pub version_to_extract: u16,
     pub flags: u16,
@@ -213,7 +214,8 @@ pub(crate) trait ZipEntryBlock {
 
 #[derive(Copy, Clone, Debug)]
 #[repr(packed, C)]
-pub(crate) struct ZipLocalEntryBlock {
+#[allow(missing_docs)]
+pub struct ZipLocalEntryBlock {
     pub version_made_by: u16,
     pub flags: u16,
     pub compression_method: u16,
@@ -261,7 +263,8 @@ impl FixedSizeBlock for ZipLocalEntryBlock {
 
 #[derive(Copy, Clone, Debug)]
 #[repr(packed, C)]
-pub(crate) struct ZipDataDescriptorBlock {
+#[allow(missing_docs)]
+pub struct ZipDataDescriptorBlock {
     pub crc32: u32,
     pub compressed_size: u32,
     pub uncompressed_size: u32,
@@ -283,7 +286,8 @@ impl FixedSizeBlock for ZipDataDescriptorBlock {
 
 #[derive(Copy, Clone, Debug)]
 #[repr(packed, C)]
-pub(crate) struct Zip64DataDescriptorBlock {
+#[allow(missing_docs)]
+pub struct Zip64DataDescriptorBlock {
     pub crc32: u32,
     pub compressed_size: u64,
     pub uncompressed_size: u64,
@@ -305,7 +309,8 @@ impl FixedSizeBlock for Zip64DataDescriptorBlock {
 
 #[derive(Copy, Clone, Debug)]
 #[repr(packed, C)]
-pub(crate) struct Zip32CDEBlock {
+#[allow(missing_docs)]
+pub struct Zip32CDEBlock {
     pub disk_number: u16,
     pub disk_with_central_directory: u16,
     pub number_of_files_on_this_disk: u16,
@@ -334,7 +339,8 @@ impl FixedSizeBlock for Zip32CDEBlock {
 }
 
 #[derive(Debug)]
-pub(crate) struct Zip32CentralDirectoryEnd {
+#[allow(missing_docs)]
+pub struct Zip32CentralDirectoryEnd {
     pub disk_number: u16,
     pub disk_with_central_directory: u16,
     pub number_of_files_on_this_disk: u16,
@@ -368,6 +374,7 @@ impl Zip32CentralDirectoryEnd {
         (block, zip_file_comment)
     }
 
+    /// Parse the block
     pub fn parse<T: Read + ?Sized>(reader: &mut T) -> ZipResult<Zip32CentralDirectoryEnd> {
         let Zip32CDEBlock {
             disk_number,
@@ -399,7 +406,8 @@ impl Zip32CentralDirectoryEnd {
             zip_file_comment,
         })
     }
-
+    
+    /// Write the block
     pub fn write<T: Write>(self, writer: &mut T) -> ZipResult<()> {
         let (block, comment) = self.into_block_and_comment();
 
@@ -412,6 +420,8 @@ impl Zip32CentralDirectoryEnd {
         Ok(())
     }
 
+    /// Check if the zip file could be a zip64
+    #[must_use]
     pub fn may_be_zip64(&self) -> bool {
         self.number_of_files == u16::MAX
             || self.central_directory_size == u32::MAX
@@ -421,7 +431,8 @@ impl Zip32CentralDirectoryEnd {
 
 #[derive(Copy, Clone)]
 #[repr(packed, C)]
-pub(crate) struct Zip64CDELocatorBlock {
+#[allow(missing_docs)]
+pub struct Zip64CDELocatorBlock {
     pub disk_with_central_directory: u32,
     pub end_of_central_directory_offset: u64,
     pub number_of_disks: u32,
@@ -442,13 +453,15 @@ impl FixedSizeBlock for Zip64CDELocatorBlock {
     ];
 }
 
-pub(crate) struct Zip64CentralDirectoryEndLocator {
+#[allow(missing_docs)]
+pub struct Zip64CentralDirectoryEndLocator {
     pub disk_with_central_directory: u32,
     pub end_of_central_directory_offset: u64,
     pub number_of_disks: u32,
 }
 
 impl Zip64CentralDirectoryEndLocator {
+    /// Parse
     pub fn parse<T: Read + ?Sized>(reader: &mut T) -> ZipResult<Zip64CentralDirectoryEndLocator> {
         let Zip64CDELocatorBlock {
             disk_with_central_directory,
@@ -464,6 +477,8 @@ impl Zip64CentralDirectoryEndLocator {
         })
     }
 
+    /// Get the block
+    #[must_use]
     pub fn block(self) -> Zip64CDELocatorBlock {
         let Self {
             disk_with_central_directory,
@@ -477,6 +492,7 @@ impl Zip64CentralDirectoryEndLocator {
         }
     }
 
+    /// Write the block
     pub fn write<T: Write>(self, writer: &mut T) -> ZipResult<()> {
         self.block().write(writer)
     }
@@ -484,7 +500,8 @@ impl Zip64CentralDirectoryEndLocator {
 
 #[derive(Copy, Clone)]
 #[repr(packed, C)]
-pub(crate) struct Zip64CDEBlock {
+#[allow(missing_docs)]
+pub struct Zip64CDEBlock {
     pub record_size: u64,
     pub version_made_by: u16,
     pub version_needed_to_extract: u16,
@@ -516,7 +533,8 @@ impl FixedSizeBlock for Zip64CDEBlock {
     ];
 }
 
-pub(crate) struct Zip64CentralDirectoryEnd {
+#[allow(missing_docs)]
+pub struct Zip64CentralDirectoryEnd {
     pub record_size: u64,
     pub version_made_by: u16,
     pub version_needed_to_extract: u16,

--- a/src/format/blocks.rs
+++ b/src/format/blocks.rs
@@ -406,7 +406,7 @@ impl Zip32CentralDirectoryEnd {
             zip_file_comment,
         })
     }
-    
+
     /// Write the block
     pub fn write<T: Write>(self, writer: &mut T) -> ZipResult<()> {
         let (block, comment) = self.into_block_and_comment();

--- a/src/format/extra_fields.rs
+++ b/src/format/extra_fields.rs
@@ -1,73 +1,135 @@
 //! Extra fields
 
+/// Known Extra Field Id from PKWARE specifications
 #[repr(u16)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(unused)]
 #[non_exhaustive]
 pub enum ExtraFieldId {
+    /// Zip64 Extended information
     Zip64ExtendedInfo = 0x0001,
-    AvInfo = 0x0007,                           // AV Info
-    ReservedExtendedLanguageEncoding = 0x0008, // Reserved for extended language encoding data (PFS)
-    Os2 = 0x0009,                              // OS/2
+    /// AV Info
+    AvInfo = 0x0007,
+    /// Reserved for extended language encoding data (PFS)
+    ReservedExtendedLanguageEncoding = 0x0008,
+    /// OS/2
+    Os2 = 0x0009,
+    /// Ntfs
     Ntfs = 0x000a,
-    OpenVms = 0x000c,                                  // OpenVMS
-    Unix = 0x000d,                                     // UNIX
-    ReservedFileStreamAndForkDescriptors = 0x000e, // Reserved for file stream and fork descriptors
-    PatchDescriptor = 0x000f,                      // Patch Descriptor
-    Pkcs7StoreForX509Certificates = 0x0014,        // PKCS#7 Store for X.509 Certificates
-    X509CertificateIdAndSignature = 0x0015, // X.509 Certificate ID and Signature for individual file
-    X509CertificateIdCentralDirectory = 0x0016, // X.509 Certificate ID for Central Directory
-    StrongEncryptionHeader = 0x0017,        // Strong Encryption Header
-    RecordManagementControls = 0x0018,      // Record Management Controls
-    Pkcs7EncryptionRecipientCertificateList = 0x0019, // PKCS#7 Encryption Recipient Certificate List
-    ReservedTimestampRecord = 0x0020,                 // Reserved for Timestamp record
-    PolicyDecryptionKeyRecord = 0x0021,               // Policy Decryption Key Record
-    SmartcryptKeyProviderRecord = 0x0022,             // Smartcrypt Key Provider Record
-    SmartcryptPolicyKeyDataRecord = 0x0023,           // Smartcrypt Policy Key Data Record
-    IbmS390As400Attributes = 0x0065, // IBM S/390 (Z390), AS/400 (I400) attributes - uncompressed
-    ReservedIbmS390As400AttributesCompressed = 0x0066, // Reserved for IBM S/390 (Z390), AS/400 (I400) attributes - compressed
+    /// OpenVMS
+    OpenVms = 0x000c,
+    /// UNIX
+    Unix = 0x000d,
+    /// Reserved for file stream and fork descriptors
+    ReservedFileStreamAndForkDescriptors = 0x000e,
+    /// Patch Descriptor
+    PatchDescriptor = 0x000f,
+    /// PKCS#7 Store for X.509 Certificates
+    Pkcs7StoreForX509Certificates = 0x0014,
+    /// X.509 Certificate ID and Signature for individual file
+    X509CertificateIdAndSignature = 0x0015,
+    /// X.509 Certificate ID for Central Directory
+    X509CertificateIdCentralDirectory = 0x0016,
+    /// Strong Encryption Header
+    StrongEncryptionHeader = 0x0017,
+    /// Record Management Controls
+    RecordManagementControls = 0x0018,
+    /// PKCS#7 Encryption Recipient Certificate List
+    Pkcs7EncryptionRecipientCertificateList = 0x0019,
+    /// Reserved for Timestamp record
+    ReservedTimestampRecord = 0x0020,
+    /// Policy Decryption Key Record
+    PolicyDecryptionKeyRecord = 0x0021,
+    /// Smartcrypt Key Provider Record
+    SmartcryptKeyProviderRecord = 0x0022,
+    /// Smartcrypt Policy Key Data Record
+    SmartcryptPolicyKeyDataRecord = 0x0023,
+    /// IBM S/390 (Z390), AS/400 (I400) attributes - uncompressed
+    IbmS390As400Attributes = 0x0065,
+    /// Reserved for IBM S/390 (Z390), AS/400 (I400) attributes - compressed
+    ReservedIbmS390As400AttributesCompressed = 0x0066,
     // Third party mappings commonly used
-    Macintosh = 0x07c8,                   // Macintosh
-    PixarUsdHeader = 0x1986,              // Pixar USD header ID
-    ZipItMacintosh = 0x2605,              // ZipIt Macintosh
-    ZipItMacintosh135Plus = 0x2705,       // ZipIt Macintosh 1.3.5+
-    ZipItMacintosh135PlusAlt = 0x2805,    // ZipIt Macintosh 1.3.5+
-    InfoZipMacintosh = 0x334d,            // Info-ZIP Macintosh
-    Tandem = 0x4154,                      // Tandem
-    AcornSparkFs = 0x4341,                // Acorn/SparkFS
-    WindowsNtSecurityDescriptor = 0x4453, // Windows NT security descriptor (binary ACL)
-    Poszip4690 = 0x4690,                  // POSZIP 4690 (reserved)
-    VmCms = 0x4704,                       // VM/CMS
-    Mvs = 0x470f,                         // MVS
-    TheosOld = 0x4854,                    // THEOS (old?)
-    FwkcsMd5 = 0x4b46,                    // FWKCS MD5
-    Os2AccessControlList = 0x4c41,        // OS/2 access control list (text ACL)
-    InfoZipOpenVms = 0x4d49,              // Info-ZIP OpenVMS
-    MacintoshSmartzip = 0x4d63,           // Macintosh Smartzip (??)
-    XceedOriginalLocation = 0x4f4c,       // Xceed original location extra field
-    AosVsAcl = 0x5356,                    // AOS/VS (ACL)
+    /// Macintosh
+    Macintosh = 0x07c8,
+    /// Pixar USD header ID
+    PixarUsdHeader = 0x1986,
+    /// ZipIt Macintosh
+    ZipItMacintosh = 0x2605,
+    /// ZipIt Macintosh 1.3.5+
+    ZipItMacintosh135Plus = 0x2705,
+    /// ZipIt Macintosh 1.3.5+
+    ZipItMacintosh135PlusAlt = 0x2805,
+    /// Info-ZIP Macintosh
+    InfoZipMacintosh = 0x334d,
+    /// Tandem
+    Tandem = 0x4154,
+    /// Acorn/SparkFS
+    AcornSparkFs = 0x4341,
+    /// Windows NT security descriptor (binary ACL)
+    WindowsNtSecurityDescriptor = 0x4453,
+    /// POSZIP 4690 (reserved)
+    Poszip4690 = 0x4690,
+    /// VM/CMS
+    VmCms = 0x4704,
+    /// MVS
+    Mvs = 0x470f,
+    /// THEOS (old?)
+    TheosOld = 0x4854,
+    /// FWKCS MD5
+    FwkcsMd5 = 0x4b46,
+    /// OS/2 access control list (text ACL)
+    Os2AccessControlList = 0x4c41,
+    /// Info-ZIP OpenVMS
+    InfoZipOpenVms = 0x4d49,
+    /// Macintosh Smartzip (??)
+    MacintoshSmartzip = 0x4d63,
+    /// Xceed original location extra field
+    XceedOriginalLocation = 0x4f4c,
+    /// AOS/VS (ACL)
+    AosVsAcl = 0x5356,
+    /// Extended Timestamp
     ExtendedTimestamp = 0x5455,
-    XceedUnicode = 0x554e,        // Xceed unicode extra field
-    InfoZipUnixOriginal = 0x5855, // Info-ZIP UNIX (original, also OS/2, NT, etc)
+    /// Xceed unicode extra field
+    XceedUnicode = 0x554e,
+    /// Info-ZIP UNIX (original, also OS/2, NT, etc)
+    InfoZipUnixOriginal = 0x5855,
+    /// Unicode comment
     UnicodeComment = 0x6375,
-    BeOsBeBox = 0x6542, // BeOS/BeBox
-    Theos = 0x6854,     // THEOS
+    /// BeOS/BeBox
+    BeOsBeBox = 0x6542,
+    /// THEOS
+    Theos = 0x6854,
+    /// Unicode Path
     UnicodePath = 0x7075,
-    AtheosSyllable = 0x7441,         // AtheOS/Syllable
-    AsiUnix = 0x756e,                // ASi UNIX
-    InfoZipUnixNew = 0x7855,         // Info-ZIP UNIX (new)
-    InfoZipUnixNewerUidGid = 0x7875, // Info-ZIP UNIX (newer UID/GID)
+    /// AtheOS/Syllable
+    AtheosSyllable = 0x7441,
+    /// ASi UNIX
+    AsiUnix = 0x756e,
+    /// Info-ZIP UNIX (new)
+    InfoZipUnixNew = 0x7855,
+    /// Info-ZIP UNIX (newer UID/GID)
+    InfoZipUnixNewerUidGid = 0x7875,
+    /// AE-X Encryption
     AeXEncryption = 0x9901,
-    Unknown9902 = 0x9902, // unknown
+    /// unknown
+    Unknown9902 = 0x9902,
+    /// DataStream Alignment
     DataStreamAlignment = 0xa11e,
-    MicrosoftOpenPackagingGrowthHint = 0xa220, // Microsoft Open Packaging Growth Hint
-    JavaJar = 0xcafe,                          // Java JAR file Extra Field Header ID
-    AndroidZipAlignment = 0xd935,              // Android ZIP Alignment Extra Field
-    KoreanZipCodePageInfo = 0xe57a,            // Korean ZIP code page info
-    SmsQdos = 0xfd4a,                          // SMS/QDOS
+    /// Microsoft Open Packaging Growth Hint
+    MicrosoftOpenPackagingGrowthHint = 0xa220,
+    /// Java JAR file Extra Field Header ID
+    JavaJar = 0xcafe,
+    /// Android ZIP Alignment Extra Field
+    AndroidZipAlignment = 0xd935,
+    /// Korean ZIP code page info
+    KoreanZipCodePageInfo = 0xe57a,
+    /// SMS/QDOS
+    SmsQdos = 0xfd4a,
 }
 
 impl ExtraFieldId {
+    /// Get value as u16
+    #[must_use]
     pub const fn as_u16(self) -> u16 {
         self as u16
     }

--- a/src/format/flags.rs
+++ b/src/format/flags.rs
@@ -109,11 +109,13 @@ impl From<System> for u8 {
 #[repr(u16)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub(crate) enum ZipFlags {
+pub enum ZipFlags {
     /// If set, indicates that the file is encrypted.
     Encrypted                   = 0b0000_0000_0000_0001,
+    /// Compression setting
     #[allow(unused)]
     CompressionSetting          = 0b0000_0000_0000_0010,
+    /// Compression setting 2
     #[allow(unused)]
     CompressionSetting2         = 0b0000_0000_0000_0100,
     /// If this bit is set, the fields crc-32, compressed size and uncompressed size are set to zero in the  local header.

--- a/src/format/magic.rs
+++ b/src/format/magic.rs
@@ -4,36 +4,47 @@
 /// struct to enforce some small amount of type safety.
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 #[repr(transparent)]
-pub(crate) struct Magic(u32);
+pub struct Magic(u32);
 
 impl Magic {
+    /// Local file header signature
     pub const LOCAL_FILE_HEADER_SIGNATURE: Self = Self::literal(0x0403_4b50);
+    /// Central directory header signature
     pub const CENTRAL_DIRECTORY_HEADER_SIGNATURE: Self = Self::literal(0x0201_4b50);
+    /// Central directory end signature
     pub const CENTRAL_DIRECTORY_END_SIGNATURE: Self = Self::literal(0x0605_4b50);
+    /// Zip64 central directory signature
     pub const ZIP64_CENTRAL_DIRECTORY_END_SIGNATURE: Self = Self::literal(0x0606_4b50);
+    /// Zip64 central directory end locator signature
     pub const ZIP64_CENTRAL_DIRECTORY_END_LOCATOR_SIGNATURE: Self = Self::literal(0x0706_4b50);
+    /// Data descriptor signature
     pub const DATA_DESCRIPTOR_SIGNATURE: Self = Self::literal(0x0807_4b50);
 
+    /// Create new literal
     pub const fn literal(x: u32) -> Self {
         Self(x)
     }
 
+    /// Create new from bytes
     #[inline(always)]
     pub const fn from_le_bytes(bytes: [u8; 4]) -> Self {
         Self(u32::from_le_bytes(bytes))
     }
 
+    /// Get as bytes
     #[inline(always)]
     pub const fn to_le_bytes(self) -> [u8; 4] {
         self.0.to_le_bytes()
     }
 
+    /// From little endian
     #[allow(clippy::wrong_self_convention)]
     #[inline(always)]
     pub fn from_le(self) -> Self {
         Self(u32::from_le(self.0))
     }
 
+    /// To little endian
     #[allow(clippy::wrong_self_convention)]
     #[inline(always)]
     pub fn to_le(self) -> Self {

--- a/src/format/magic.rs
+++ b/src/format/magic.rs
@@ -21,18 +21,21 @@ impl Magic {
     pub const DATA_DESCRIPTOR_SIGNATURE: Self = Self::literal(0x0807_4b50);
 
     /// Create new literal
+    #[must_use]
     pub const fn literal(x: u32) -> Self {
         Self(x)
     }
 
     /// Create new from bytes
     #[inline(always)]
+    #[must_use]
     pub const fn from_le_bytes(bytes: [u8; 4]) -> Self {
         Self(u32::from_le_bytes(bytes))
     }
 
     /// Get as bytes
     #[inline(always)]
+    #[must_use]
     pub const fn to_le_bytes(self) -> [u8; 4] {
         self.0.to_le_bytes()
     }
@@ -40,6 +43,7 @@ impl Magic {
     /// From little endian
     #[allow(clippy::wrong_self_convention)]
     #[inline(always)]
+    #[must_use]
     pub fn from_le(self) -> Self {
         Self(u32::from_le(self.0))
     }
@@ -47,6 +51,7 @@ impl Magic {
     /// To little endian
     #[allow(clippy::wrong_self_convention)]
     #[inline(always)]
+    #[must_use]
     pub fn to_le(self) -> Self {
         Self(u32::to_le(self.0))
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,14 +1,15 @@
 //! Zip format
 
-pub(crate) mod aes;
-pub(crate) mod blocks;
-pub(crate) mod extra_fields;
+pub mod aes;
+pub mod blocks;
+pub mod extra_fields;
 pub(crate) mod find_central_directory;
-pub(crate) mod flags;
+pub mod flags;
 pub(crate) mod functions;
-pub(crate) mod magic;
+pub mod magic;
 
-pub(crate) mod ffi {
+/// ffi for Windows
+pub mod ffi {
     /// Regular
     pub const S_IFREG: u32 = 0b1000_0000_0000_0000; // 0o0_100_000
     /// Directory
@@ -74,7 +75,10 @@ pub(crate) use find_central_directory::find_central_directory_end;
 /// # }
 ///```
 pub const ZIP64_BYTES_THR: u64 = u32::MAX as u64;
+
+/// Same as `ZIP64_BYTES_THR` but as `u32`
 pub const ZIP64_BYTES_THR_U32: u32 = u32::MAX;
+
 /// The number of entries within a single zip necessary to allocate a zip64 central
 /// directory record.
 ///

--- a/src/read/zipfile.rs
+++ b/src/read/zipfile.rs
@@ -134,7 +134,7 @@ macro_rules! zip_file_methods {
 
         /// Get the system of the file
         pub fn system(&self) -> System {
-            &self.get_metadata().system
+            self.get_metadata().system
         }
 
         /// Get the compression method used to store the file

--- a/src/read/zipfile.rs
+++ b/src/read/zipfile.rs
@@ -133,7 +133,7 @@ macro_rules! zip_file_methods {
         }
 
         /// Get the system of the file
-        pub fn system(&self) -> &System {
+        pub fn system(&self) -> System {
             &self.get_metadata().system
         }
 

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -20,6 +20,11 @@ use std::path::{Component, MAIN_SEPARATOR, Path};
 pub mod stream {
     pub use crate::read::stream::{ZipStreamReader, ZipStreamVisitor};
 }
+
+/// Zip format
+pub mod format {
+    pub use crate::format::*;
+}
 /// Types for creating ZIP archives.
 pub mod write {
     use crate::result::{ZipError, ZipResult};


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
