### PR TITLE
feat: add test to in place modification

### DIFF
--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -461,3 +461,101 @@ fn test_zip_file_entry_to_reader() {
     file_with_reader.read_to_end(&mut content).unwrap();
     assert_eq!(content, b"data");
 }
+
+#[test]
+fn modify_in_place_with_trait() {
+    use zip::HasZipMetadata;
+    use zip::ZipArchive;
+    // With the trait, the archive needs to be mut
+
+    // create a zip
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let datetime = (23825, 44746).try_into().unwrap();
+    let options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .last_modified_time(datetime);
+    writer.start_file("my_file.txt", options).unwrap();
+    writer.write_all(b"data").unwrap();
+
+    let mut zip_raw = writer.finish().unwrap().into_inner();
+
+    {
+        // check current date
+        let reader_zip = Cursor::new(&zip_raw);
+        let mut zip_archive = ZipArchive::new(reader_zip).unwrap();
+        let file = zip_archive.by_name("my_file.txt").unwrap();
+        let date = file.get_metadata().last_modified_time.unwrap();
+        assert_eq!(date.datepart(), 23825);
+        assert_eq!(date.timepart(), 44746);
+    }
+
+    let start = {
+        let reader_zip = Cursor::new(&zip_raw);
+        let mut zip_archive = ZipArchive::new(reader_zip).unwrap();
+        let file = zip_archive.by_name("my_file.txt").unwrap();
+        file.get_metadata().central_header_start as usize
+    };
+
+    let offset_date = start + 14;
+    zip_raw[offset_date] += 10;
+
+    {
+        // check new date
+        let reader_zip = Cursor::new(&zip_raw);
+        let mut zip_archive = ZipArchive::new(reader_zip).unwrap();
+        let file = zip_archive.by_name("my_file.txt").unwrap();
+        let date = file.get_metadata().last_modified_time.unwrap();
+        assert_eq!(date.datepart(), 23835); // changed!
+        assert_eq!(date.timepart(), 44746);
+    }
+}
+
+#[test]
+fn modify_in_place_with_data() {
+    use zip::ZipArchive;
+    // Without the trait, the archive doesn't need to be mut
+
+    // create a zip
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let datetime = (23825, 44746).try_into().unwrap();
+    let options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .last_modified_time(datetime);
+    writer.start_file("my_file.txt", options).unwrap();
+    writer.write_all(b"data").unwrap();
+
+    let mut zip_raw = writer.finish().unwrap().into_inner();
+
+    {
+        // check current date
+        let reader_zip = Cursor::new(&zip_raw);
+        let zip_archive = ZipArchive::new(reader_zip).unwrap();
+        let file_number = zip_archive.index_for_path("my_file.txt").unwrap();
+        let file = zip_archive.by_index_data(file_number).unwrap();
+        let date = file.last_modified().unwrap();
+        assert_eq!(date.datepart(), 23825);
+        assert_eq!(date.timepart(), 44746);
+    }
+
+    let start = {
+        let reader_zip = Cursor::new(&zip_raw);
+        let mut zip_archive = ZipArchive::new(reader_zip).unwrap();
+        let file = zip_archive.by_name("my_file.txt").unwrap();
+        file.central_header_start() as usize
+    };
+
+    let offset_date = start + 14;
+    zip_raw[offset_date] += 10;
+
+    {
+        // check new date
+        let reader_zip = Cursor::new(&zip_raw);
+        let zip_archive = ZipArchive::new(reader_zip).unwrap();
+        let file_number = zip_archive.index_for_path("my_file.txt").unwrap();
+        let file = zip_archive.by_index_data(file_number).unwrap();
+        let date = file.last_modified().unwrap();
+        assert_eq!(date.datepart(), 23835); // changed!
+        assert_eq!(date.timepart(), 44746);
+    }
+
+}

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -557,5 +557,4 @@ fn modify_in_place_with_data() {
         assert_eq!(date.datepart(), 23835); // changed!
         assert_eq!(date.timepart(), 44746);
     }
-
 }


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->


fix https://github.com/zip-rs/zip2/issues/168