### PR TITLE
refactor: remove unused trait

### DIFF
--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -26,20 +26,6 @@ pub use zipinfo_utf8::UnicodeExtraField;
 pub use crate::format::extra_fields::EXTRA_FIELD_MAPPING;
 use crate::format::extra_fields::ExtraFieldId;
 
-/// Marker trait to denote the place where this extra field has been stored.
-pub trait ExtraFieldVersion {}
-
-/// Marker type for extra fields specified in a local file header.
-#[derive(Debug, Clone)]
-pub struct LocalHeaderVersion;
-
-/// Use this marker type for extra fields specified in the central header.
-#[derive(Debug, Clone)]
-pub struct CentralHeaderVersion;
-
-impl ExtraFieldVersion for LocalHeaderVersion {}
-impl ExtraFieldVersion for CentralHeaderVersion {}
-
 /// Internal extra-field identifiers (`u16` tags) recognized by this crate.
 ///
 /// This enum is crate-private and used for matching/dispatch on raw ZIP extra

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -13,7 +13,7 @@ zip = \"="]
 
 use std::borrow::Cow;
 use std::io;
-use std::io::{Read, Write};
+use std::io::Read;
 use std::path::{Component, MAIN_SEPARATOR, Path};
 
 /// Provides high level API for reading from a stream.
@@ -58,30 +58,6 @@ pub mod write {
         }
     }
 }
-
-/// Helper methods for writing unsigned integers in little-endian form.
-pub trait LittleEndianWriteExt: Write {
-    /// Write a u16 as little endian
-    fn write_u16_le(&mut self, input: u16) -> io::Result<()> {
-        self.write_all(&input.to_le_bytes())
-    }
-    /// Write a u32 as little endian
-    fn write_u32_le(&mut self, input: u32) -> io::Result<()> {
-        self.write_all(&input.to_le_bytes())
-    }
-
-    /// Write a u64 as little endian
-    fn write_u64_le(&mut self, input: u64) -> io::Result<()> {
-        self.write_all(&input.to_le_bytes())
-    }
-
-    /// Write a u128 as little endian
-    fn write_u128_le(&mut self, input: u128) -> io::Result<()> {
-        self.write_all(&input.to_le_bytes())
-    }
-}
-
-impl<W: Write + ?Sized> LittleEndianWriteExt for W {}
 
 /// Helper methods for reading unsigned integers in little-endian form.
 pub trait LittleEndianReadExt: Read {

--- a/src/write.rs
+++ b/src/write.rs
@@ -276,7 +276,6 @@ pub(crate) mod zip_writer {
 pub use self::options::sealed::FileOptionExtension;
 use crate::CompressionMethod::Stored;
 use crate::result::ZipError::UnsupportedArchive;
-use crate::unstable::LittleEndianWriteExt;
 use crate::unstable::path_to_string;
 use crate::zipcrypto::CHUNK_SIZE;
 pub use zip_writer::ZipWriter;
@@ -1289,12 +1288,12 @@ impl<W: Write + Seek> ZipWriter<W> {
 
             // Overwrite the magic so the footer is no longer valid.
             writer.seek(SeekFrom::Start(central_start))?;
-            writer.write_u32_le(0)?;
+            writer.write_all(&0_u32.to_le_bytes())?;
             let start_zip32_cde = footer_end
                 - (size_of::<Magic>() + size_of::<Zip32CDEBlock>()) as u64
                 - self.comment.len() as u64;
             writer.seek(SeekFrom::Start(start_zip32_cde))?;
-            writer.write_u32_le(0)?;
+            writer.write_all(&0_u32.to_le_bytes())?;
             let zip64_extensible_len = self
                 .zip64_extensible_data_sector
                 .as_ref()
@@ -1304,12 +1303,12 @@ impl<W: Write + Seek> ZipWriter<W> {
                 let start_zip64_locator = start_zip32_cde
                     - (size_of::<Magic>() + size_of::<Zip64CentralDirectoryEndLocator>()) as u64;
                 writer.seek(SeekFrom::Start(start_zip64_locator))?;
-                writer.write_u32_le(0)?;
+                writer.write_all(&0_u32.to_le_bytes())?;
                 let start_zip64_cde = start_zip64_locator
                     - (size_of::<Magic>() + Zip64CentralDirectoryEnd::MIN_FULL_SIZE) as u64
                     - zip64_extensible_len;
                 writer.seek(SeekFrom::Start(start_zip64_cde))?;
-                writer.write_u32_le(0)?;
+                writer.write_all(&0_u32.to_le_bytes())?;
             }
 
             // Rewrite the footer at the actual end.
@@ -1886,10 +1885,10 @@ impl ZipFileData {
         writer.seek(SeekFrom::Start(
             self.header_start + (size_of::<Magic>() + offset_of!(ZipLocalEntryBlock, crc32)) as u64,
         ))?;
-        writer.write_u32_le(self.crc32)?;
+        writer.write_all(&self.crc32.to_le_bytes())?;
         if self.large_file {
-            writer.write_u32_le(ZIP64_BYTES_THR_U32)?;
-            writer.write_u32_le(ZIP64_BYTES_THR_U32)?;
+            writer.write_all(&ZIP64_BYTES_THR_U32.to_le_bytes())?;
+            writer.write_all(&ZIP64_BYTES_THR_U32.to_le_bytes())?;
 
             self.update_local_zip64_extra_field(writer, file_name_raw)?;
         } else {
@@ -1899,9 +1898,9 @@ impl ZipFileData {
                     "large_file(true) option has not been set",
                 )));
             }
-            writer.write_u32_le(self.compressed_size as u32)?;
+            writer.write_all(&(self.compressed_size as u32).to_le_bytes())?;
             // uncompressed size is already checked on write to catch it as soon as possible
-            writer.write_u32_le(self.uncompressed_size as u32)?;
+            writer.write_all(&(self.uncompressed_size as u32).to_le_bytes())?;
         }
         Ok(())
     }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 use std::io::{Cursor, Read, Seek, Write};
 use zip::result::ZipResult;
-use zip::unstable::LittleEndianWriteExt;
 use zip::write::ExtendedFileOptions;
 use zip::write::FileOptions;
 use zip::write::SimpleFileOptions;
@@ -179,8 +178,8 @@ fn check_test_archive<R: Read + Seek>(zip_file: R) -> ZipResult<zip::ZipArchive<
         // Check an archive file for extra data field contents.
         let file_with_extra_data = archive.by_name("test_with_extra_data/🐢.txt")?;
         let mut extra_field = Vec::new();
-        extra_field.write_u16_le(0xbeef)?;
-        extra_field.write_u16_le(EXTRA_DATA.len() as u16)?;
+        extra_field.write_all(&0xbeef_u16.to_le_bytes())?;
+        extra_field.write_all(&(EXTRA_DATA.len() as u16).to_le_bytes())?;
         extra_field.write_all(EXTRA_DATA)?;
         assert_eq!(file_with_extra_data.extra_data(), Some(extra_field));
     }


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
