### PR TITLE
feat: add compression to `src/format`

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -3,6 +3,8 @@
 use core::fmt;
 use std::{fmt::Debug, io};
 
+use crate::format::compression::Compression;
+
 #[allow(deprecated)]
 /// Identifies the storage format used to compress a file within a ZIP archive.
 ///
@@ -263,6 +265,52 @@ impl CompressionMethod {
     #[must_use]
     pub const fn to_u16(self) -> u16 {
         self.serialize_to_u16()
+    }
+
+    /// Transform to `Compression`
+    #[must_use]
+    pub const fn into_compression(self) -> Compression {
+        match self {
+            CompressionMethod::Stored => Compression::Stored,
+            #[cfg(feature = "legacy-zip")]
+            CompressionMethod::Shrink => Compression::Shrink,
+            #[cfg(feature = "legacy-zip")]
+            CompressionMethod::Reduce(n) => match n {
+                1 => Compression::ReduceFactor1,
+                2 => Compression::ReduceFactor2,
+                3 => Compression::ReduceFactor3,
+                4 => Compression::ReduceFactor4,
+                _ => Compression::Unknown(n as u16),
+            },
+            #[cfg(feature = "legacy-zip")]
+            CompressionMethod::Implode => Compression::Implode,
+            #[cfg(feature = "_deflate-any")]
+            CompressionMethod::Deflated => Compression::Deflated,
+            #[cfg(feature = "deflate64")]
+            CompressionMethod::Deflate64 => Compression::Deflate64,
+            #[cfg(feature = "_bzip2_any")]
+            CompressionMethod::Bzip2 => Compression::Bzip2,
+            #[cfg(feature = "zstd")]
+            CompressionMethod::Zstd => Compression::Zstd,
+            #[cfg(feature = "lzma")]
+            CompressionMethod::Lzma => Compression::Lzma,
+            #[cfg(feature = "xz")]
+            CompressionMethod::Xz => Compression::Xz,
+            #[cfg(feature = "ppmd")]
+            CompressionMethod::Ppmd => Compression::Ppmd,
+            // E.4 The compression method field (section 4.4.5) is set to 99
+            // to indicate a file has been encrypted using this method.
+            #[cfg(feature = "aes-crypto")]
+            CompressionMethod::Aes => Compression::Aes,
+            #[allow(deprecated)]
+            CompressionMethod::Unsupported(v) => Compression::Unknown(v),
+        }
+    }
+}
+
+impl From<CompressionMethod> for Compression {
+    fn from(value: CompressionMethod) -> Self {
+        value.into_compression()
     }
 }
 
@@ -624,5 +672,13 @@ mod tests {
         for &method in SUPPORTED_COMPRESSION_METHODS {
             check_match(method);
         }
+    }
+
+    #[cfg(feature = "legacy-zip")]
+    #[test]
+    fn check_reduce() {
+        assert_eq!(CompressionMethod::Reduce(1), CompressionMethod::REDUCE_1);
+        assert_eq!(CompressionMethod::Reduce(1).serialize_to_u16(), 2);
+        assert_eq!(CompressionMethod::REDUCE_1.serialize_to_u16(), 2);
     }
 }

--- a/src/format/compression.rs
+++ b/src/format/compression.rs
@@ -1,0 +1,150 @@
+//! Compression
+
+/// Compression
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+#[repr(u16)]
+#[non_exhaustive]
+pub enum Compression {
+    /// Store the file as is
+    #[default]
+    Stored = 0,
+    /// Method 1 Shrink
+    Shrink = 1,
+    /// Reduce with compression factor 1
+    ReduceFactor1 = 2,
+    /// Reduce with compression factor 2
+    ReduceFactor2 = 3,
+    /// Reduce with compression factor 3
+    ReduceFactor3 = 4,
+    /// Reduce with compression factor 4
+    ReduceFactor4 = 5,
+    /// Implode/explode
+    Implode = 6,
+    /// Reserved for Tokenizing compression algorithm
+    TokenizingCompression = 7,
+    /// Compress the file using Deflate
+    Deflated = 8,
+    /// Compress the file using Deflate64.
+    Deflate64 = 9,
+    /// PKWARE Data Compression Library Imploding (old IBM TERSE)
+    PkwareDataCompressionImploding = 10,
+    /// Reserved by PKWARE
+    Reserved11 = 11,
+    /// Compress the file using BZIP2
+    Bzip2 = 12,
+    /// Reserved by PKWARE
+    Reserved13 = 13,
+    /// Compress the file using LZMA
+    Lzma = 14,
+    /// Reserved by PKWARE
+    Reserved15 = 15,
+    /// IBM z/OS CMPSC Compression
+    CmpscCompression = 16,
+    /// Reserved by PKWARE
+    Reserved17 = 17,
+    /// File is compressed using IBM TERSE (new)
+    IbmTerseNew = 18,
+    /// IBM LZ77 z Architecture
+    IbmLz77 = 19,
+    /// deprecated ZSTD
+    DeprecatedZstd = 20,
+    /// Compress the file using `ZStandard`
+    Zstd = 93,
+    /// MP3 Compression
+    Mp3 = 94,
+    /// Compress the file using XZ
+    Xz = 95,
+    /// JPEG variant
+    Jpeg = 96,
+    /// WavPack compressed data
+    WavPack = 97,
+    /// Compress the file using `PPMd`
+    Ppmd = 98,
+    /// Encrypted using AES.
+    ///
+    /// The actual compression method has to be taken from the AES extra data field
+    /// or from `ZipFileData`.
+    Aes = 99,
+    /// Unsupported compression method
+    Unknown(u16),
+}
+
+impl From<u16> for Compression {
+    fn from(value: u16) -> Self {
+        match value {
+            0 => Self::Stored,
+            1 => Self::Shrink,
+            2 => Self::ReduceFactor1,
+            3 => Self::ReduceFactor2,
+            4 => Self::ReduceFactor3,
+            5 => Self::ReduceFactor4,
+            6 => Self::Implode,
+            7 => Self::TokenizingCompression,
+            8 => Self::Deflated,
+            9 => Self::Deflate64,
+            10 => Self::PkwareDataCompressionImploding,
+            11 => Self::Reserved11,
+            12 => Self::Bzip2,
+            13 => Self::Reserved13,
+            14 => Self::Lzma,
+            15 => Self::Reserved15,
+            16 => Self::CmpscCompression,
+            17 => Self::Reserved17,
+            18 => Self::IbmTerseNew,
+            19 => Self::IbmLz77,
+            20 => Self::DeprecatedZstd,
+            93 => Self::Zstd,
+            94 => Self::Mp3,
+            95 => Self::Xz,
+            96 => Self::Jpeg,
+            97 => Self::WavPack,
+            98 => Self::Ppmd,
+            99 => Self::Aes,
+            n => Self::Unknown(n),
+        }
+    }
+}
+
+impl From<Compression> for u16 {
+    fn from(value: Compression) -> Self {
+        match value {
+            Compression::Stored => 0,
+            Compression::Shrink => 1,
+            Compression::ReduceFactor1 => 2,
+            Compression::ReduceFactor2 => 3,
+            Compression::ReduceFactor3 => 4,
+            Compression::ReduceFactor4 => 5,
+            Compression::Implode => 6,
+            Compression::TokenizingCompression => 7,
+            Compression::Deflated => 8,
+            Compression::Deflate64 => 9,
+            Compression::PkwareDataCompressionImploding => 10,
+            Compression::Reserved11 => 11,
+            Compression::Bzip2 => 12,
+            Compression::Reserved13 => 13,
+            Compression::Lzma => 14,
+            Compression::Reserved15 => 15,
+            Compression::CmpscCompression => 16,
+            Compression::Reserved17 => 17,
+            Compression::IbmTerseNew => 18,
+            Compression::IbmLz77 => 19,
+            Compression::DeprecatedZstd => 20,
+            Compression::Zstd => 93,
+            Compression::Mp3 => 94,
+            Compression::Xz => 95,
+            Compression::Jpeg => 96,
+            Compression::WavPack => 97,
+            Compression::Ppmd => 98,
+            Compression::Aes => 99,
+            Compression::Unknown(value) => value,
+        }
+    }
+}
+
+impl Compression {
+    /// as u16
+    #[must_use]
+    pub fn as_u16(self) -> u16 {
+        u16::from(self)
+    }
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod aes;
 pub mod blocks;
+pub mod compression;
 pub mod extra_fields;
 pub(crate) mod find_central_directory;
 pub mod flags;


### PR DESCRIPTION
- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).


Only in `format/` (at least for now) because it would be a quite big breaking change I think.

For me, the current `CompressionMethod` should be more like `AvailableCompressionMethod` with some gated-behind-features enum variant.

And `Compression` should not be feature dependent - like code in `format/` (almost)