### PR TITLE
fix: preserve unix permission in raw_copy_file

### DIFF
--- a/src/read/zipfile.rs
+++ b/src/read/zipfile.rs
@@ -375,14 +375,13 @@ impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
         let mut options = SimpleFileOptions::default()
             .large_file(self.compressed_size().max(self.size()) >= ZIP64_BYTES_THR)
             .compression_method(self.compression())
-            .unix_permissions(self.unix_mode().unwrap_or(0o644) | ffi::S_IFREG)
             .last_modified_time(
                 self.last_modified()
                     .filter(DateTime::is_valid)
                     .unwrap_or_else(DateTime::default_for_write),
             );
+        options.permissions = self.unix_mode();
 
-        options.normalize();
         #[cfg(feature = "aes-crypto")]
         if let Some((mode, vendor_version)) = self.get_metadata().aes_settings() {
             use crate::write::options::EncryptWith;

--- a/src/read/zipfile.rs
+++ b/src/read/zipfile.rs
@@ -375,6 +375,7 @@ impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
         let mut options = SimpleFileOptions::default()
             .large_file(self.compressed_size().max(self.size()) >= ZIP64_BYTES_THR)
             .compression_method(self.compression())
+            .system(self.system())
             .external_attributes(self.external_attributes())
             .last_modified_time(
                 self.last_modified()

--- a/src/read/zipfile.rs
+++ b/src/read/zipfile.rs
@@ -375,13 +375,14 @@ impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
         let mut options = SimpleFileOptions::default()
             .large_file(self.compressed_size().max(self.size()) >= ZIP64_BYTES_THR)
             .compression_method(self.compression())
+            .external_attributes(self.external_attributes())
             .last_modified_time(
                 self.last_modified()
                     .filter(DateTime::is_valid)
                     .unwrap_or_else(DateTime::default_for_write),
             );
-        options.permissions = self.unix_mode();
-
+        
+        options.normalize();
         #[cfg(feature = "aes-crypto")]
         if let Some((mode, vendor_version)) = self.get_metadata().aes_settings() {
             use crate::write::options::EncryptWith;

--- a/src/read/zipfile.rs
+++ b/src/read/zipfile.rs
@@ -381,7 +381,7 @@ impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
                     .filter(DateTime::is_valid)
                     .unwrap_or_else(DateTime::default_for_write),
             );
-        
+
         options.normalize();
         #[cfg(feature = "aes-crypto")]
         if let Some((mode, vendor_version)) = self.get_metadata().aes_settings() {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -82,6 +82,41 @@ fn test_copy_zip_entries() {
     });
 }
 
+#[test]
+fn test_copy_zip_symlink() {
+    const LINK_NAME: &str = "symlink";
+    const LINK_TARGET: &str = "link-target";
+    for_each_supported_method(|method| {
+        let mut src_archive = {
+            let mut zip = zip::ZipWriter::new(Cursor::new(Vec::new()));
+            zip.add_symlink_from_path(
+                LINK_NAME,
+                LINK_TARGET,
+                zip::write::SimpleFileOptions::DEFAULT.compression_method(method),
+            )
+            .unwrap();
+            zip.finish_into_readable().unwrap()
+        };
+        let mut tgt_archive = {
+            let mut zip = zip::ZipWriter::new(Cursor::new(Vec::new()));
+            zip.raw_copy_file(src_archive.by_name(LINK_NAME).unwrap())
+                .unwrap();
+            zip.finish_into_readable().unwrap()
+        };
+
+        let src_file = src_archive.by_name(LINK_NAME).unwrap();
+        let mut tgt_file = tgt_archive.by_name(LINK_NAME).unwrap();
+
+        {
+            let mut dest_buf = String::new();
+            tgt_file.read_to_string(&mut dest_buf).unwrap();
+            assert_eq!(dest_buf.as_str(), LINK_TARGET);
+        }
+        assert_eq!(src_file.compression(), tgt_file.compression());
+        assert_eq!(src_file.unix_mode(), tgt_file.unix_mode());
+    });
+}
+
 // This test asserts that after appending to a `ZipWriter`, then reading its contents back out,
 // both the prior data and the appended data will be exactly the same as their originals.
 #[test]


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
Fix #954