### PR TITLE
fix: clippy warning on nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,11 +240,11 @@ jobs:
       - run: rustup toolchain add nightly && rustup default nightly
 
       - name: resolve minimal versions
-        run: cargo -Z minimal-versions update --manifest-path ${{ github.workspace }}/${{ matrix.workspace }}
+        run: cargo +nightly -Z minimal-versions update --manifest-path ${{ github.workspace }}/${{ matrix.workspace }}
       - name: check
-        run: cargo check --all-features --manifest-path ${{ github.workspace }}/${{ matrix.workspace }}
+        run: cargo +nightly check --all-features --manifest-path ${{ github.workspace }}/${{ matrix.workspace }}
       - name: test
-        run: cargo test --all-features --manifest-path ${{ github.workspace }}/${{ matrix.workspace }}
+        run: cargo +nightly test --all-features --manifest-path ${{ github.workspace }}/${{ matrix.workspace }}
 
   style_and_docs:
     strategy:

--- a/examples/append.rs
+++ b/examples/append.rs
@@ -61,23 +61,18 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    let to_append = match PathBuf::from_str(append_dir_path) {
-        Ok(path) => {
-            if path.is_absolute() {
-                return Err("Absolute paths are not allowed".into());
-            }
-            if path
-                .components()
-                .any(|c| matches!(c, std::path::Component::ParentDir))
-            {
-                return Err("Parent directory references (..) are not allowed".into());
-            }
-            base_dir.join(path)
+    let to_append = {
+        let path = PathBuf::from(append_dir_path);
+        if path.is_absolute() {
+            return Err("Absolute paths are not allowed".into());
         }
-        Err(e) => {
-            eprintln!("Invalid path: {}", e);
-            return Err(e.into());
+        if path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err("Parent directory references (..) are not allowed".into());
         }
+        base_dir.join(path)
     };
     let to_append = match to_append.canonicalize() {
         Ok(p) => p,

--- a/examples/append.rs
+++ b/examples/append.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 use std::{
     fs::{File, OpenOptions},
     path::{Path, PathBuf},
-    str::FromStr,
 };
 use zip::write::SimpleFileOptions;
 
@@ -44,9 +43,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         return Err("Wrong usage".into());
     }
 
-    let existing_archive_path = &*args[1];
-    let append_dir_path = &*args[2];
-    let archive = PathBuf::from_str(existing_archive_path).unwrap();
+    let existing_archive_path = PathBuf::from(&*args[1]);
+    let append_dir_path = PathBuf::from(&*args[2]);
     let base_dir = match std::env::current_dir() {
         Ok(dir) => match dir.canonicalize() {
             Ok(c) => c,
@@ -61,19 +59,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    let to_append = {
-        let path = PathBuf::from(append_dir_path);
-        if path.is_absolute() {
-            return Err("Absolute paths are not allowed".into());
-        }
-        if path
-            .components()
-            .any(|c| matches!(c, std::path::Component::ParentDir))
-        {
-            return Err("Parent directory references (..) are not allowed".into());
-        }
-        base_dir.join(path)
-    };
+    if append_dir_path.is_absolute() {
+        return Err("Absolute paths are not allowed".into());
+    }
+    if append_dir_path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err("Parent directory references (..) are not allowed".into());
+    }
+    let to_append = base_dir.join(append_dir_path);
     let to_append = match to_append.canonicalize() {
         Ok(p) => p,
         Err(e) => {
@@ -89,7 +84,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let existing_zip = OpenOptions::new()
         .read(true)
         .write(true)
-        .open(archive)
+        .open(existing_archive_path)
         .unwrap();
     let mut append_zip = zip::ZipWriter::new_append(existing_zip).unwrap();
 


### PR DESCRIPTION


- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).


`PathBuf::from_str` has an Infallible error, it's better to directly use `PathBuf::from`