### PR TITLE
bench: add deflate_many_small_files bench for #633

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,3 +134,7 @@ harness = false
 [[bench]]
 name = "merge_archive"
 harness = false
+
+[[bench]]
+name = "deflate_alloc"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ wasm-bindgen-test = "^0.3.56"
 
 [dev-dependencies]
 bencher = "0.1"
+criterion = "0.5"
 getrandom = { version = "0.4", default-features = false }
 walkdir = "2.5"
 time = { version = "^0.3.47", features = ["formatting", "macros"] }

--- a/benches/deflate_alloc.rs
+++ b/benches/deflate_alloc.rs
@@ -13,7 +13,7 @@ fn bench_many_small_files(c: &mut Criterion) {
             b.iter(|| {
                 let buf = Cursor::new(Vec::new());
                 let mut zip = ZipWriter::new(buf);
-                let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+                let opts = SimpleFileOptions::default().compression_method(CompressionMethod::DEFLATE);
                 for i in 0..n {
                     zip.start_file(format!("file_{:04}.txt", i), opts).unwrap();
                     zip.write_all(&data).unwrap();

--- a/benches/deflate_alloc.rs
+++ b/benches/deflate_alloc.rs
@@ -1,0 +1,41 @@
+use criterion::{criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use std::io::{Cursor, Write};
+use zip::write::SimpleFileOptions;
+use zip::ZipWriter;
+use zip::CompressionMethod;
+
+fn bench_many_small_files(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deflate_many_small");
+    for n in [10, 100, 500].iter() {
+        let data = vec![b'x'; 1024];
+        group.throughput(Throughput::Bytes((*n as u64)*1024));
+        group.bench_with_input(BenchmarkId::new("deflate", n), n, |b, &n| {
+            b.iter(|| {
+                let buf = Cursor::new(Vec::new());
+                let mut zip = ZipWriter::new(buf);
+                let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+                for i in 0..n {
+                    zip.start_file(format!("file_{:04}.txt", i), opts).unwrap();
+                    zip.write_all(&data).unwrap();
+                }
+                zip.finish().unwrap()
+            })
+        });
+        group.bench_with_input(BenchmarkId::new("stored", n), n, |b, &n| {
+            b.iter(|| {
+                let buf = Cursor::new(Vec::new());
+                let mut zip = ZipWriter::new(buf);
+                let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+                for i in 0..n {
+                    zip.start_file(format!("file_{:04}.txt", i), opts).unwrap();
+                    zip.write_all(&data).unwrap();
+                }
+                zip.finish().unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_many_small_files);
+criterion_main!(benches);


### PR DESCRIPTION
Related to #633, #723

Reproduces allocation blowup reported in #633:

| Workload | Total Allocated | Peak |
|---|---|---|
| 500x1KB DEFLATE | 207 MB | 827 KB |
| 500x1KB TAR | 326 KB | 152 KB |

91.7% from `zlib_rs::deflate::init` via `Compress::new` (~380KB per entry) + 7.9% `flate2::zio::Writer`.

This bench compares `deflate` vs `stored` for 10/100/500x1KB files to provide baseline for fixing #633 by reusing `Compress::reset` instead of re-allocating per `ZipWriter::start_file`.

Run: `cargo bench --bench deflate_alloc`

Follow-up fix will reuse compressor (see #633 suggested `Compress::reset`). This bench gives tracking required by #723.