### PR TITLE
fix: expose flags function for easier access in `ZipFileData`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -144,13 +144,13 @@ impl ZipFileData {
 
     /// Check if the encrypted flag is set
     #[inline]
-    pub(crate) fn is_encrypted(&self) -> bool {
+    pub fn is_encrypted(&self) -> bool {
         self.flags.is_encrypted()
     }
 
     /// Check if the data descriptor flag is set
     #[inline]
-    pub(crate) fn is_using_data_descriptor(&self) -> bool {
+    pub fn is_using_data_descriptor(&self) -> bool {
         self.flags.is_using_data_descriptor()
     }
 


### PR DESCRIPTION
- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
