### PR TITLE
Use >= for the compressed size in central_header

### DIFF
--- a/src/extra_fields/zip64_extended_information.rs
+++ b/src/extra_fields/zip64_extended_information.rs
@@ -72,9 +72,10 @@ impl Zip64ExtendedInformation {
         header_start: u64,
     ) -> Option<Self> {
         let mut size: u16 = 0;
+        // >= matches local_header and the other ZIP64 size checks in the crate
         let sizes = if is_large_file
             || uncompressed_size >= ZIP64_BYTES_THR
-            || compressed_size > ZIP64_BYTES_THR
+            || compressed_size >= ZIP64_BYTES_THR
         {
             size += mem::size_of::<u64>() as u16 + mem::size_of::<u64>() as u16;
             Some(Zip64Sizes {
@@ -220,5 +221,48 @@ impl Zip64ExtendedInformation {
         }
 
         Ok((new_uncompressed_size, new_compressed_size, new_header_start))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_and_central_agree_at_the_threshold() {
+        // The two constructors decide the same question, so they must agree for
+        // every input; ZIP64_BYTES_THR itself is the only value where they did not.
+        for size in [ZIP64_BYTES_THR - 1, ZIP64_BYTES_THR, ZIP64_BYTES_THR + 1] {
+            for (uncompressed, compressed) in [(0, size), (size, 0)] {
+                let local = Zip64ExtendedInformation::local_header(false, uncompressed, compressed);
+                let central =
+                    Zip64ExtendedInformation::central_header(false, uncompressed, compressed, 0);
+                let want = size >= ZIP64_BYTES_THR;
+                assert_eq!(
+                    local.is_some(),
+                    want,
+                    "local_header({uncompressed}, {compressed})"
+                );
+                assert_eq!(
+                    central.is_some_and(|c| c.sizes.is_some()),
+                    want,
+                    "central_header({uncompressed}, {compressed})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn central_header_treats_both_sizes_alike() {
+        let by_uncompressed =
+            Zip64ExtendedInformation::central_header(false, ZIP64_BYTES_THR, 0, 0);
+        let by_compressed = Zip64ExtendedInformation::central_header(false, 0, ZIP64_BYTES_THR, 0);
+        assert_eq!(
+            by_uncompressed.is_some(),
+            by_compressed.is_some(),
+            "the two size terms disagree at the threshold",
+        );
+        // A size of exactly ZIP64_BYTES_THR does not fit a u32 field, so both must ask for ZIP64.
+        assert!(by_uncompressed.is_some_and(|c| c.sizes.is_some()));
     }
 }

--- a/src/extra_fields/zip64_extended_information.rs
+++ b/src/extra_fields/zip64_extended_information.rs
@@ -72,7 +72,6 @@ impl Zip64ExtendedInformation {
         header_start: u64,
     ) -> Option<Self> {
         let mut size: u16 = 0;
-        // >= matches local_header and the other ZIP64 size checks in the crate
         let sizes = if is_large_file
             || uncompressed_size >= ZIP64_BYTES_THR
             || compressed_size >= ZIP64_BYTES_THR


### PR DESCRIPTION
`local_header` and `central_header` (`src/extra_fields/zip64_extended_information.rs`) decide the same question -- does this entry need the ZIP64 extended information field -- and they disagree on one input.

`local_header:53`:
```rust
let should_add_size = is_large_file
    || uncompressed_size >= ZIP64_BYTES_THR
    || compressed_size >= ZIP64_BYTES_THR;
```

`central_header:75`:
```rust
let sizes = if is_large_file
    || uncompressed_size >= ZIP64_BYTES_THR
    || compressed_size > ZIP64_BYTES_THR      // <-
```

`ZIP64_BYTES_THR` is `u32::MAX` (`src/format/mod.rs:79`). At `compressed_size == u32::MAX` with a smaller uncompressed size and `large_file` false, `local_header` returns the extra field and `central_header` does not -- the local header asks for ZIP64 sizes and the central directory omits them for the same entry.

## Four other checks on this quantity use `>=`

- the `uncompressed_size` term on the line directly above it
- `local_header:55`
- `ZipFileData::write_data_descriptor` (`src/types.rs:439`): `if self.compressed_size >= ZIP64_BYTES_THR || self.uncompressed_size >= ZIP64_BYTES_THR`
- `src/read/zipfile.rs:376`: `.large_file(self.compressed_size().max(self.size()) >= ZIP64_BYTES_THR)`

`>=` is also the correct boundary on its own terms: `u32::MAX` is the sentinel that means "look in the ZIP64 field", so a real size of exactly `u32::MAX` cannot be stored in the 32-bit field. `clamp_size_field` (`src/types.rs:427`) agrees -- when `large_file` is false it writes `size.min(ZIP64_BYTES_THR_U32 - 1)`, i.e. it will not emit `u32::MAX` as a literal size.

`git log -L 51,56` shows both constructors arrived together in `f2536faf` ("fix: zip64 central header (issue 617) (#629)"), so this is a transcription slip inside one commit rather than a later divergence.

## The fix

One character, plus a test. Both constructors are `pub(crate)`, so the case is reachable from a crate-internal unit test without writing a 4 GiB entry.

## Verification

`cargo test -p zip` -- 32 test binaries all ok. `cargo clippy -p zip --all-targets` -- 0 errors; the one warning it reports (`used assert_eq! with a literal bool` in `tests/data_descriptor.rs`) is present on `master` too. `cargo fmt --check` clean.

The test sweeps both size fields across below / at / above the threshold and asserts the two constructors agree. On `master` it fails with `central_header(0, 4294967295)`.

I mutation-checked all four comparisons, each on its own -- weakening any one of them to `>` fails:

| site | result |
|---|---|
| `local_header` uncompressed | fails |
| `local_header` compressed | fails |
| `central_header` uncompressed | fails |
| `central_header` compressed | fails |

A note on how I got there, because my first attempt lied to me: the two functions contain the *same* comparison text, so a naive single-occurrence substitution mutated `local_header` while I believed I was mutating `central_header`, and reported a false survivor. Anchoring each mutation to its enclosing function fixed it -- and the false survivor did point at a real gap, since my first test only varied the compressed size and so left the two `uncompressed_size` terms unpinned.

## Behaviour change

Only at `compressed_size == u32::MAX` exactly, with `large_file` false. Below and above the threshold nothing moves, and no existing test row changes -- the suite is green unmodified.

## What I did not change

`src/write.rs:1414`'s `central_size.max(central_start) > ZIP64_BYTES_THR`. It has the same shape but decides something different -- whether to emit the ZIP64 end-of-central-directory record, from an offset rather than an entry size -- and I have no evidence about the intent there, so it did not belong in this diff. Happy to look at it separately if you think it is the same slip.

---

Disclosure: AI-assisted. I found and prepared this with an AI assistant, and I ran and verified everything above myself.
