### PR TITLE
fix: rewrite documentation of add_symlink_from_path

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -1332,9 +1332,11 @@ impl<W: Write + Seek> ZipWriter<W> {
 
     /// Add a symlink entry, taking Paths to the location and target as arguments.
     ///
+    /// This function sanitizes both the path and the target. If you don't want to sanitize the
+    /// path, it's recommended to use the normal [`Self::add_symlink`]
+    ///
     /// This function ensures that the '/' path separator is used and normalizes `.` and `..`. It
-    /// ignores any `..` or Windows drive letter that would produce a path outside the ZIP file's
-    /// root.
+    /// ignores any `..` or Windows drive letter
     pub fn add_symlink_from_path<P: AsRef<Path>, T: AsRef<Path>, E: FileOptionExtension>(
         &mut self,
         path: P,


### PR DESCRIPTION
- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->

fix https://github.com/zip-rs/zip2/issues/969
