### PR TITLE
fix: add unix_mode when copy_raw_file

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -1218,6 +1218,7 @@ impl<W: Write + Seek> ZipWriter<W> {
         options = options.last_modified_time(last_modified_time);
 
         if let Some(perms) = unix_mode {
+            options.external_attributes = None;
             options = options.unix_permissions(perms);
         }
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -145,31 +145,33 @@ fn test_raw_copy_file_permissions() {
     use zip::DateTime;
     use zip::unstable::format::ffi;
 
-    let mut src_archive = {
-        let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
-        b.start_file("file", zip::write::FileOptions::DEFAULT)
+    for_each_supported_method(|method| {
+        let mut src_archive = {
+            let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+            let options = SimpleFileOptions::default().compression_method(method);
+            b.start_file("file", options).unwrap();
+            b.finish_into_readable().unwrap()
+        };
+        let datetime = DateTime::from_date_and_time(2026, 1, 1, 10, 10, 10).unwrap();
+        let unix_mode = 0o777;
+        let mut tgt_archive = {
+            let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+            b.raw_copy_file_touch(
+                src_archive.by_name("file").unwrap(),
+                datetime,
+                Some(unix_mode),
+            )
             .unwrap();
-        b.finish_into_readable().unwrap()
-    };
-    let datetime = DateTime::from_date_and_time(2026, 1, 1, 10, 10, 10).unwrap();
-    let unix_mode = 0o777;
-    let mut tgt_archive = {
-        let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
-        b.raw_copy_file_touch(
-            src_archive.by_name("file").unwrap(),
-            datetime,
-            Some(unix_mode),
-        )
-        .unwrap();
-        b.finish_into_readable().unwrap()
-    };
+            b.finish_into_readable().unwrap()
+        };
 
-    let src_file = src_archive.by_name("file").unwrap();
-    let tgt_file = tgt_archive.by_name("file").unwrap();
+        let src_file = src_archive.by_name("file").unwrap();
+        let tgt_file = tgt_archive.by_name("file").unwrap();
 
-    assert_eq!(src_file.compression(), tgt_file.compression());
-    assert_eq!(tgt_file.last_modified(), Some(datetime));
-    assert_eq!(tgt_file.unix_mode(), Some(unix_mode | ffi::S_IFREG));
+        assert_eq!(src_file.compression(), tgt_file.compression());
+        assert_eq!(tgt_file.last_modified(), Some(datetime));
+        assert_eq!(tgt_file.unix_mode(), Some(unix_mode | ffi::S_IFREG));
+    });
 }
 
 // This test asserts that after appending to a `ZipWriter`, then reading its contents back out,

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -173,7 +173,7 @@ fn test_raw_copy_file_permissions() {
 
         // Windows: `unix_mode()` gives the default mode
         #[cfg(windows)]
-        assert_eq!(file.unix_mode(), Some(0o664 | ffi::S_IFREG));
+        assert_eq!(tgt_file.unix_mode(), Some(0o664 | ffi::S_IFREG));
 
         #[cfg(not(windows))]
         assert_eq!(tgt_file.unix_mode(), Some(unix_mode | ffi::S_IFREG));

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -140,6 +140,38 @@ fn test_raw_copy_dir() {
     assert_eq!(src_dir.unix_mode(), tgt_dir.unix_mode());
 }
 
+#[test]
+fn test_raw_copy_file_permissions() {
+    use zip::DateTime;
+    use zip::unstable::format::ffi;
+
+    let mut src_archive = {
+        let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        b.start_file("file", zip::write::FileOptions::DEFAULT)
+            .unwrap();
+        b.finish_into_readable().unwrap()
+    };
+    let datetime = DateTime::from_date_and_time(2026, 1, 1, 10, 10, 10).unwrap();
+    let unix_mode = 0o777;
+    let mut tgt_archive = {
+        let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        b.raw_copy_file_touch(
+            src_archive.by_name("file").unwrap(),
+            datetime,
+            Some(unix_mode),
+        )
+        .unwrap();
+        b.finish_into_readable().unwrap()
+    };
+
+    let src_file = src_archive.by_name("file").unwrap();
+    let tgt_file = tgt_archive.by_name("file").unwrap();
+
+    assert_eq!(src_file.compression(), tgt_file.compression());
+    assert_eq!(tgt_file.last_modified(), Some(datetime));
+    assert_eq!(tgt_file.unix_mode(), Some(unix_mode | ffi::S_IFREG));
+}
+
 // This test asserts that after appending to a `ZipWriter`, then reading its contents back out,
 // both the prior data and the appended data will be exactly the same as their originals.
 #[test]

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -170,6 +170,12 @@ fn test_raw_copy_file_permissions() {
 
         assert_eq!(src_file.compression(), tgt_file.compression());
         assert_eq!(tgt_file.last_modified(), Some(datetime));
+
+        // Windows: `unix_mode()` gives the default mode
+        #[cfg(windows)]
+        assert_eq!(file.unix_mode(), Some(0o664 | ffi::S_IFREG));
+
+        #[cfg(not(windows))]
         assert_eq!(tgt_file.unix_mode(), Some(unix_mode | ffi::S_IFREG));
     });
 }


### PR DESCRIPTION
- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
