### PR TITLE
fix: copy extra fields in raw_copy_file (#955)

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -25,6 +25,7 @@ use core::mem::{self, offset_of, size_of};
 use core::str::{Utf8Error, from_utf8};
 use crc32fast::Hasher;
 use indexmap::IndexMap;
+use std::io::Cursor;
 use std::io::ErrorKind;
 use std::io::{self, Read, Seek, Write};
 use std::io::{BufReader, SeekFrom};
@@ -1118,6 +1119,18 @@ impl<W: Write + Seek> ZipWriter<W> {
         let mut options = file.options().into_full_options();
         if !file.comment().is_empty() {
             options = options.with_file_comment(file.comment());
+        }
+        for one_extra in file.extra_data_fields() {
+            let mut buff = Cursor::new(Vec::new());
+            one_extra.write(&mut buff, false)?;
+            let buff = buff.into_inner();
+            if buff.len() >= 4 {
+                options.add_extra_field(
+                    u16::from_le_bytes([buff[0], buff[1]]),
+                    &buff[4..],
+                    false,
+                )?;
+            }
         }
         let file_name = name.to_string();
         self.raw_copy_file_rename_internal(file, file_name.as_bytes(), options)

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -142,34 +142,37 @@ fn test_raw_copy_dir() {
 
 #[test]
 fn test_raw_copy_extra_fields() {
-    let mut src_archive = {
-        let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
-        let mut options = SimpleFileOptions::default().into_full_options();
-        options.add_extra_field(87_u16, b"abc", false).unwrap();
-        b.start_file("file", options)
-            .unwrap();
-        b.finish_into_readable().unwrap()
-    };
-    let mut tgt_archive = {
-        let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
-        b.raw_copy_file(src_archive.by_name("file").unwrap())
-            .unwrap();
-        b.finish_into_readable().unwrap()
-    };
+    for_each_supported_method(|method| {
+        let mut src_archive = {
+            let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+            let mut options = SimpleFileOptions::default()
+                .compression_method(method)
+                .into_full_options();
+            options.add_extra_field(87_u16, b"abc", false).unwrap();
+            b.start_file("file", options).unwrap();
+            b.finish_into_readable().unwrap()
+        };
+        let mut tgt_archive = {
+            let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+            b.raw_copy_file(src_archive.by_name("file").unwrap())
+                .unwrap();
+            b.finish_into_readable().unwrap()
+        };
 
-    let src_file = src_archive.by_name("file").unwrap();
-    let tgt_file = tgt_archive.by_name("file").unwrap();
+        let src_file = src_archive.by_name("file").unwrap();
+        let tgt_file = tgt_archive.by_name("file").unwrap();
 
-    assert_eq!(src_file.compression(), tgt_file.compression());
-    assert_eq!(src_file.unix_mode(), tgt_file.unix_mode());
-    assert_eq!(
-        src_file.extra_data().unwrap(),
-        vec![87, 0, 3, 0, b'a', b'b', b'c']
-    );
-    assert_eq!(
-        src_file.extra_data().unwrap(),
-        tgt_file.extra_data().unwrap()
-    );
+        assert_eq!(src_file.compression(), tgt_file.compression());
+        assert_eq!(src_file.unix_mode(), tgt_file.unix_mode());
+        assert_eq!(
+            src_file.extra_data().unwrap(),
+            vec![87, 0, 3, 0, b'a', b'b', b'c']
+        );
+        assert_eq!(
+            src_file.extra_data().unwrap(),
+            tgt_file.extra_data().unwrap()
+        );
+    });
 }
 
 // This test asserts that after appending to a `ZipWriter`, then reading its contents back out,

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -140,6 +140,38 @@ fn test_raw_copy_dir() {
     assert_eq!(src_dir.unix_mode(), tgt_dir.unix_mode());
 }
 
+#[test]
+fn test_raw_copy_extra_fields() {
+    let mut src_archive = {
+        let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        let mut options = SimpleFileOptions::default().into_full_options();
+        options.add_extra_field(87_u16, b"abc", false).unwrap();
+        b.start_file("file", options)
+            .unwrap();
+        b.finish_into_readable().unwrap()
+    };
+    let mut tgt_archive = {
+        let mut b = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        b.raw_copy_file(src_archive.by_name("file").unwrap())
+            .unwrap();
+        b.finish_into_readable().unwrap()
+    };
+
+    let src_file = src_archive.by_name("file").unwrap();
+    let tgt_file = tgt_archive.by_name("file").unwrap();
+
+    assert_eq!(src_file.compression(), tgt_file.compression());
+    assert_eq!(src_file.unix_mode(), tgt_file.unix_mode());
+    assert_eq!(
+        src_file.extra_data().unwrap(),
+        vec![87, 0, 3, 0, b'a', b'b', b'c']
+    );
+    assert_eq!(
+        src_file.extra_data().unwrap(),
+        tgt_file.extra_data().unwrap()
+    );
+}
+
 // This test asserts that after appending to a `ZipWriter`, then reading its contents back out,
 // both the prior data and the appended data will be exactly the same as their originals.
 #[test]


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->


should fix #955